### PR TITLE
New Array serializer and changes to existing Json serializer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .settings
 *.log
 test/*.db
+*.swp

--- a/lib/Model.php
+++ b/lib/Model.php
@@ -1623,6 +1623,18 @@ class Model
   }
 
 	/**
+	 * Returns an Array representation of this model.
+	 *
+	 * @see Serialization
+	 * @param array $options An array containing options for json serialization (see {@link Serialization} for valid options)
+	 * @return array Array representation of the model
+	 */
+	public function to_array(array $options=array())
+	{
+		return $this->serialize('Array', $options);
+	}
+
+	/**
 	 * Creates a serializer based on pre-defined to_serializer()
 	 *
 	 * An options array can take the following parameters:
@@ -1635,7 +1647,7 @@ class Model
 	 * <li><b>include:</b> a string or array of associated models to include in the final serialized product.</li>
 	 * </ul>
 	 *
-	 * @param string $type Either Xml or Json
+	 * @param string $type Either Xml, Json or Array
 	 * @param array $options Options array for the serializer
 	 * @return string Serialized representation of the model
 	 */

--- a/lib/Serialization.php
+++ b/lib/Serialization.php
@@ -240,17 +240,33 @@ abstract class Serialization
 };
 
 /**
- * JSON serializer.
+ * Array serializer.
  *
  * @package ActiveRecord
  */
-class JsonSerializer extends Serialization
+class ArraySerializer extends Serialization
 {
 	public static $include_root = false;
 
 	public function to_s()
 	{
-		return json_encode(self::$include_root ? array(strtolower(get_class($this->model)) => $this->to_a()) : $this->to_a());
+		return self::$include_root ? array(strtolower(get_class($this->model)) => $this->to_a()) : $this->to_a();
+	}
+}
+
+/**
+ * JSON serializer.
+ *
+ * @package ActiveRecord
+ */
+class JsonSerializer extends ArraySerializer
+{
+	public static $include_root = false;
+
+	public function to_s()
+	{
+		parent::$include_root = self::$include_root;
+		return json_encode(parent::to_s());
 	}
 }
 

--- a/test/SerializationTest.php
+++ b/test/SerializationTest.php
@@ -9,6 +9,7 @@ class SerializationTest extends DatabaseTest
 	public function tear_down()
 	{
 		parent::tear_down();
+		ActiveRecord\ArraySerializer::$include_root = false;
 		ActiveRecord\JsonSerializer::$include_root = false;
 	}
 
@@ -122,6 +123,31 @@ class SerializationTest extends DatabaseTest
 		$book = Book::find(1);
 		$this->assert_equals($book->attributes(),get_object_vars(new SimpleXMLElement($book->to_xml())));
 	}
+
+  public function test_to_array()
+  {
+ 		$book = Book::find(1);
+		$array = $book->to_array();
+		$this->assert_equals($book->attributes(), $array);
+  }
+
+  public function test_to_array_include_root()
+  {
+		ActiveRecord\ArraySerializer::$include_root = true;
+ 		$book = Book::find(1);
+		$array = $book->to_array();
+    $book_attributes = array('book' => $book->attributes());
+		$this->assert_equals($book_attributes, $array);
+  }
+
+  public function test_to_array_except()
+  {
+ 		$book = Book::find(1);
+		$array = $book->to_array(array('except' => array('special')));
+		$book_attributes = $book->attributes();
+		unset($book_attributes['special']);
+		$this->assert_equals($book_attributes, $array);
+  }
 
 	public function test_works_with_datetime()
 	{


### PR DESCRIPTION
Hi,

I had a requirement to $User->to_array() and $User->attributes() wasn't appropriate in the particular scenario because I wanted to exclude the password attribute and I didn't want to override attributes(), so I override to_array() in User like so: -

```
class User extends Model

    public function to_array() {

      $options = array(
        'except' => array('password')
      );

      return parent::to_array($options);
    }
}
```

As the Json and Array serialization code is mostly the same, I made the Json serializer extend the Array serializer.  Not sure if that's the best approach, but it made the code more DRY.

Commit - https://github.com/asha79/php-activerecord/commit/b669e413b198aceae03075988e5b9fcfd7338092

Ash.
