### PR TITLE
Issue #100 fixed

### DIFF
--- a/lib/Relationship.php
+++ b/lib/Relationship.php
@@ -147,6 +147,8 @@ abstract class AbstractRelationship implements InterfaceRelationship
 
 		if (!empty($includes))
 			$options['include'] = $includes;
+			
+		$options = $this->unset_non_finder_options($options);
 
 		$class = $this->class_name;
 


### PR DESCRIPTION
After GH-93 there appeared an issue with unwanted keys like **class_name**, **through** and others in $options array for **relationships**. This commit fixes this issue.
