### PR TITLE
Gh98: Delegates to getters produce a warning

### DIFF
--- a/lib/Model.php
+++ b/lib/Model.php
@@ -199,7 +199,7 @@ class Model
 	 *
 	 * This is the opposite of {@link attr_accessible $attr_accessible} and the format
 	 * for defining these are exactly the same.
-	 * 
+	 *
 	 * If the attribute is both accessible and protected, it is treated as protected.
 	 *
 	 * @var array
@@ -503,7 +503,7 @@ class Model
 				$to = $item['to'];
 				if ($this->$to)
 				{
-					$val =& $this->$to->$delegated_name;
+					$val =& $this->$to->__get($delegated_name);
 					return $val;
 				}
 				else

--- a/test/ActiveRecordTest.php
+++ b/test/ActiveRecordTest.php
@@ -365,11 +365,33 @@ class ActiveRecordTest extends DatabaseTest
 		$this->assert_null($event->state);
 	}
 
-	public function test_delegate_setter()
+	public function test_delegate_set_attribute()
 	{
 		$event = Event::first();
 		$event->state = 'MEXICO';
 		$this->assert_equals('MEXICO',$event->venue->state);
+	}
+
+	public function test_delegate_getter_gh_98()
+	{
+		Venue::$use_custom_get_state_getter = true;
+
+		$event = Event::first();
+		$this->assert_equals('ny', $event->venue->state);
+		$this->assert_equals('ny', $event->state);
+
+		Venue::$use_custom_get_state_getter = false;
+	}
+
+	public function test_delegate_setter_gh_98()
+	{
+		Venue::$use_custom_set_state_setter = true;
+
+		$event = Event::first();
+		$event->state = 'MEXICO';
+		$this->assert_equals('MEXICO#',$event->venue->state);
+
+		Venue::$use_custom_set_state_setter = false;
 	}
 
 	public function test_table_name_with_underscores()

--- a/test/models/Venue.php
+++ b/test/models/Venue.php
@@ -1,6 +1,10 @@
 <?php
 class Venue extends ActiveRecord\Model
 {
+	static $use_custom_get_state_getter = false;
+	static $use_custom_set_state_setter = false;
+	
+	
 	static $has_many = array(
 		'events',
 		array('hosts', 'through' => 'events')
@@ -12,5 +16,22 @@ class Venue extends ActiveRecord\Model
 		'marquee' => 'name',
 		'mycity' => 'city'
 	);
+	
+	public function get_state()
+	{
+		if (self::$use_custom_get_state_getter)
+			return strtolower($this->read_attribute('state'));
+		else
+			return $this->read_attribute('state');
+	}
+	
+	public function set_state($value)
+	{
+		if (self::$use_custom_set_state_setter)
+			return $this->assign_attribute('state', $value . '#');
+		else
+			return $this->assign_attribute('state', $value);
+	}
+	
 };
 ?>


### PR DESCRIPTION
replaced direct attribute access with explicit call to __get().
