### PR TITLE
allow join_primary_key override

### DIFF
--- a/lib/Relationship.php
+++ b/lib/Relationship.php
@@ -342,7 +342,7 @@ abstract class AbstractRelationship implements InterfaceRelationship
 			if ($using_through)
 			{
 				$foreign_key = $this->primary_key[0];
-				$join_primary_key = $this->foreign_key[0];
+				$join_primary_key = isset($this->options['join_primary_key']) ? $this->options['join_primary_key'] : $this->foreign_key[0];
 			}
 			else
 			{
@@ -432,7 +432,7 @@ class HasMany extends AbstractRelationship
 	 *
 	 * @var array
 	 */
-	static protected $valid_association_options = array('primary_key', 'order', 'group', 'having', 'limit', 'offset', 'through', 'source');
+	static protected $valid_association_options = array('primary_key', 'order', 'group', 'having', 'limit', 'offset', 'through', 'source','join_primary_key');
 
 	protected $primary_key;
 


### PR DESCRIPTION
Hey,

Firstly thanks for the good work on PHP-AR as a Rails dev this at least easies some of my pain and makes coming back to PHP a lot nicer!

Anyways this is a little/tiny hack that basically allows an override for join_primary_key on many to many through associations.

Details of my problem this resolves can be found on your forum.

http://www.phpactiverecord.org/boards/4/topics/734-re-associations-through-on-legacy-db

Thanks.

P
