### PR TITLE
MySQL ids should be unsigned ints

### DIFF
--- a/lib/adapters/MysqlAdapter.php
+++ b/lib/adapters/MysqlAdapter.php
@@ -81,7 +81,7 @@ class MysqlAdapter extends Connection
 	public function native_database_types()
 	{
 		return array(
-			'primary_key' => 'int(11) DEFAULT NULL auto_increment PRIMARY KEY',
+			'primary_key' => 'int(11) UNSIGNED DEFAULT NULL auto_increment PRIMARY KEY',
 			'string' => array('name' => 'varchar', 'length' => 255),
 			'text' => array('name' => 'text'),
 			'integer' => array('name' => 'int', 'length' => 11),


### PR DESCRIPTION
MySQL primary keys should be unsigned integers to make better use of the integer space (ids are > 0 anyway).
