### PR TITLE
attribute_is_dirty cannot find index error

### DIFF
--- a/lib/Model.php
+++ b/lib/Model.php
@@ -548,7 +548,7 @@ class Model
 	 */
 	public function attribute_is_dirty($attribute)
 	{
-		return $this->__dirty && $this->__dirty[$attribute] && array_key_exists($attribute, $this->attributes);
+		return $this->__dirty && array_key_exists($attribute, $this->attributes) && array_key_exists($attribute, $this->__dirty);
 	}
 
 	/**


### PR DESCRIPTION
Error fix for "public function attribute_is_dirty", where attribute index does not exist in "$__dirty".
