### PR TITLE
php-ar for modular use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.log
 test/*.db
 *.swp
+.idea

--- a/ActiveRecord.php
+++ b/ActiveRecord.php
@@ -47,12 +47,19 @@ $paths = ActiveRecord\Config::instance()->get_model_directories();
 
 		//if file exists, include it.
 		$file = "$root/$class_name.php";
-		
+		log_message('debug','Searching for '.$class_name.' class in '.$file);
 		if (file_exists($file))
 		{
+			log_message('debug',basename($file).' found.');
 			require $file;
-			if(class_exists($class_name, false)) break; //make double-sure the file actually contains the class we're after
+			if(class_exists($class_name, false)) 
+			{
+				log_message('debug','....and class '.$class_name.' exists.');
+				break; //make double-sure the file actually contains the class we're after
+			}
+			else log_message('error','.....but class '.$class_name.' is not there!');
 		}
+		else log_message('debug',basename($file).' not found there.  Alas.');
 
 	}
 }

--- a/lib/Config.php
+++ b/lib/Config.php
@@ -219,7 +219,8 @@ class Config extends Singleton
 		
 		//put new directory at the beginning of the array, since client code will 
 		// tend to add a model directory right before using a model in that directory.
-		array_unshift($this->model_directories,$dir);
+		if(!in_array($dir,$this->model_directories))
+			array_unshift($this->model_directories,$dir);
 	}
 	
 	/**

--- a/lib/Config.php
+++ b/lib/Config.php
@@ -50,13 +50,14 @@ class Config extends Singleton
 	 */
 	private $connections = array();
 
+
 	/**
 	 * Directory for the auto_loading of model classes.
 	 *
 	 * @see activerecord_autoload
-	 * @var string
+	 * @var array
 	 */
-	private $model_directory;
+	private $model_directories = array();
 
 	/**
 	 * Switch for logging.
@@ -191,29 +192,46 @@ class Config extends Singleton
 
 	/**
 	 * Sets the directory where models are located.
-	 *
+	 * 
+	 * @deprecated Use add_model_directory() instead
 	 * @param string $dir Directory path containing your models
 	 * @return void
 	 */
 	public function set_model_directory($dir)
 	{
-		$this->model_directory = $dir;
+		$this->add_model_directory($dir);
 	}
-
+	
 	/**
-	 * Returns the model directory.
-	 *
-	 * @return string
-	 * @throws ConfigException if specified directory was not found
+	 * Add a directory to the model directories array.
+	 * 
+	 * @throws ConfigException
+	 * @param string $dir
+	 * @return void
 	 */
-	public function get_model_directory()
+	public function add_model_directory($dir = '')
 	{
-		if ($this->model_directory && !file_exists($this->model_directory))
-			throw new ConfigException('Invalid or non-existent directory: '.$this->model_directory);
-
-		return $this->model_directory;
+		if(empty($dir))
+			throw new ConfigException('Cannot add an empty string to model directories.');
+		
+		if (!file_exists($dir))
+			throw new ConfigException('Cannot add invalid or non-existent model directory: '.$dir);
+		
+		//put new directory at the beginning of the array, since client code will 
+		// tend to add a model directory right before using a model in that directory.
+		array_unshift($this->model_directories,$dir);
 	}
-
+	
+	/**
+	 * Get an array of model directories.
+	 * 
+	 * @return array
+	 */
+	public function get_model_directories()
+	{
+		return $this->model_directories;
+	}
+	
 	/**
 	 * Turn on/off logging
 	 *
@@ -301,4 +319,4 @@ class Config extends Singleton
 		Cache::initialize($url,$options);
 	}
 };
-?>
+


### PR DESCRIPTION
Modified ActiveRecord\Config to use an array of model directory paths, and updated the autoloader accordingly. This is to facilitate usage in modular applications. Retains existing set_model_directory() method for backward compability.
Also added .idea (PHP Storm project file) to .gitignore.
