### PR TITLE
null return saving models with camel-style pk

### DIFF
--- a/lib/Table.php
+++ b/lib/Table.php
@@ -269,7 +269,7 @@ class Table
 	{
 		foreach ($this->columns as $raw_name => $column)
 		{
-			if ($column->inflected_name == $inflected_name)
+			if ($raw_name == $inflected_name)
 				return $column;
 		}
 		return null;


### PR DESCRIPTION
lib/table.php line 272. If someone set a pk in the model with camel style (ex: productId), the old line would take "productid" and send a notice "Notice: Trying to get property of non-object", because this function returns null.
