### PR TITLE
Fixing tests for PHPUnit 3.6

### DIFF
--- a/test/RelationshipTest.php
+++ b/test/RelationshipTest.php
@@ -541,7 +541,7 @@ class RelationshipTest extends DatabaseTest
 
 		foreach ($assocs as $assoc)
 		{
-			$this->assert_type('array', $authors[0]->$assoc);
+			$this->assert_internal_type('array', $authors[0]->$assoc);
 
 			foreach ($authors[0]->$assoc as $a)
 				$this->assert_equals($authors[0]->author_id,$a->author_id);
@@ -549,7 +549,7 @@ class RelationshipTest extends DatabaseTest
 
 		foreach ($assocs as $assoc)
 		{
-			$this->assert_type('array', $authors[1]->$assoc);
+			$this->assert_internal_type('array', $authors[1]->$assoc);
 			$this->assert_true(empty($authors[1]->$assoc));
 		}
 


### PR DESCRIPTION
Tests are failing using PHPUnit 3.6 because of an old API is used.
