### PR TITLE
Define REGEXP for sqlite

### DIFF
--- a/lib/adapters/SqliteAdapter.php
+++ b/lib/adapters/SqliteAdapter.php
@@ -19,6 +19,7 @@ class SqliteAdapter extends Connection
 			throw new DatabaseException("Could not find sqlite db: $info->host");
 
 		$this->connection = new PDO("sqlite:$info->host",null,null,static::$PDO_OPTIONS);
+        $this->connection->sqliteCreateFunction('regexp', '\\ActiveRecord\\SqliteAdapter::sqlite_regexp', 2);
 	}
 
 	public function limit($sql, $offset, $limit)
@@ -102,6 +103,17 @@ class SqliteAdapter extends Connection
 			'boolean' => array('name' => 'boolean')
 		);
 	}
+
+    public static function sqlite_regexp($pattern, $string)
+    {
+        /* Insert delimiter if needed */
+        if(!preg_match('/^([^[:alnum:]\\\s]).*?\1[imsxUXJ]*$/', $pattern))
+        {
+            $pattern = '/'.$pattern.'/';
+        }
+        return preg_match($pattern, $string);
+    }
+
 
 }
 ?>


### PR DESCRIPTION
Sqlite has REGEXP as a reserved keyword but doesn't implement any functionality for it. Instead you have to do it yourself by registring a user defined function named REGEXP().

I've written a rather simple version that tries to mimic the MySQL implementation which automatically inserts delimiters if none are present. I think this should definitly be in php-activerecord to make applications more database-independant.

And before someone asks: no, I haven't written a test for it but I might do later.
