### PR TITLE
support custom COUNT like COUNT(DISTINCT col)

### DIFF
--- a/lib/Model.php
+++ b/lib/Model.php
@@ -1409,7 +1409,7 @@ class Model
 	{
 		$args = func_get_args();
 		$options = static::extract_and_validate_options($args);
-		if (! isset($options['select'])) $options['select'] = 'COUNT(*)';
+		if (! isset($options['select']) || strpos($options['select'], 'COUNT') === false) $options['select'] = 'COUNT(*)';
 
 		if (!empty($args) && !is_null($args[0]) && !empty($args[0]))
 		{


### PR DESCRIPTION
when we need some SQL like

SELECT COUNT(DISTINCT UsersUrls.`Index`) FROM `UsersUrls` JOIN UsersUrlsCategories ON UsersUrlsCategories.UrlIndex = UsersUrls.Index JOIN UrlsSearchTerms ON UrlsSearchTerms.UrlIndex = UsersUrls.Index JOIN SearchTerms ON SearchTerms.`Index`=UrlsSearchTerms.SearchTermIndex WHERE UsersUrls.UserIndex = ? AND UsersUrlsCategories.CategoryIndex IN (?) AND SearchTerms.SearchEngineIndex IN (?)

the patch would be helpful that we can set

$searchcnd['select'] = 'COUNT(DISTINCT UsersUrls.`Index`)';
$total = UsersUrls::count($searchcnd);

we can't approach our SQL with COUNT(*).

Thanks.
