### PR TITLE
Allow use of SQL_CALC_FOUND_ROWS for MySQL as a finder option.

### DIFF
--- a/lib/Model.php
+++ b/lib/Model.php
@@ -1270,7 +1270,7 @@ class Model
 	 *
 	 * @var array
 	 */
-	static $VALID_OPTIONS = array('conditions', 'limit', 'offset', 'order', 'select', 'joins', 'include', 'readonly', 'group', 'from', 'having');
+	static $VALID_OPTIONS = array('conditions', 'limit', 'offset', 'order', 'select', 'joins', 'include', 'readonly', 'group', 'from', 'having', 'mysql_calc_found_rows');
 
 	/**
 	 * Enables the use of dynamic finders.

--- a/lib/SQLBuilder.php
+++ b/lib/SQLBuilder.php
@@ -22,6 +22,7 @@ class SQLBuilder
 	private $group;
 	private $having;
 	private $update;
+  private $mysql_calc_found_rows = false;
 
 	// for where
 	private $where;
@@ -98,6 +99,11 @@ class SQLBuilder
 		$this->apply_where_conditions(func_get_args());
 		return $this;
 	}
+
+	public function mysql_calc_found_rows($mysql_calc_found_rows) {
+	  $this->mysql_calc_found_rows = $mysql_calc_found_rows;
+	  return $this;
+  }
 
 	public function order($order)
 	{
@@ -363,7 +369,13 @@ class SQLBuilder
 
 	private function build_select()
 	{
-		$sql = "SELECT $this->select FROM $this->table";
+		//$sql = "SELECT $this->select FROM $this->table";
+    $sql = "SELECT ";
+    if ($this->mysql_calc_found_rows) {
+      $sql .= " SQL_CALC_FOUND_ROWS ";
+    }
+    
+    $sql .=	 "$this->select FROM $this->table";
 
 		if ($this->joins)
 			$sql .= ' ' . $this->joins;


### PR DESCRIPTION
SQL_CALC_FOUND_ROWS is really a necessary evil if your doing pagination on a MySQL server.. The alternative is to do it with double queries for everything which is really not efficient..

This allows the following:

list ($count, $rows) = SomeModel::find('all', array('mysql_calc_found_rows' => true);

The reason you can't just do this with putting the value in the SELECT field is that if you do any includes, by the time you get control again to do a query for FOUND_ROWS(), it will be overwritten by the value from the include query.

