### PR TITLE
fixed the many-to-many through association when using 'include'

### DIFF
--- a/lib/Relationship.php
+++ b/lib/Relationship.php
@@ -171,7 +171,10 @@ abstract class AbstractRelationship implements InterfaceRelationship
       $through_models = $class::find('all', $through_options);
       $through_models = group_collect($through_models, $query_key, $this->foreign_key[0]);
 
-      $options['select'] = 'DISTINCT `' . $this->attribute_name . '`.*';
+      $linking_table = $this->class_name;
+      $linking_table = $linking_table::table();
+
+      $options['select'] = 'DISTINCT `' . $linking_table->table . '`.*';
 			$options['joins'] = $this->construct_inner_join_sql($through_table, true);
 
 			$query_key = $this->primary_key[0];

--- a/lib/Serialization.php
+++ b/lib/Serialization.php
@@ -173,7 +173,7 @@ abstract class Serialization
 				try {
 					$assoc = $this->model->$association;
 
-					if (!is_array($assoc))
+					if (!is_array($assoc) && !is_null($assoc))
 					{
 						$serialized = new $serializer_class($assoc, $options);
 						$this->attributes[$association] = $serialized->to_a();;

--- a/lib/Utils.php
+++ b/lib/Utils.php
@@ -136,6 +136,21 @@ function collect(&$enumerable, $name_or_closure)
 	return $ret;
 }
 
+function group_collect(&$enumerable, $group_by, $name_or_closure)
+{
+  $ret = array();
+
+  foreach ($enumerable as $value)
+  {
+    $key = is_array($value) ? $value[$group_by] : $value->$group_by;
+    if (is_string($name_or_closure))
+      $ret[$key][] = is_array($value) ? $value[$name_or_closure] : $value->$name_or_closure;
+    elseif ($name_or_closure instanceof Closure)
+      $ret[$key][] = $name_or_closure($value);
+  }
+  return $ret;
+}
+
 /**
  * Wrap string definitions (if any) into arrays.
  */
@@ -143,7 +158,7 @@ function wrap_strings_in_arrays(&$strings)
 {
 	if (!is_array($strings))
 		$strings = array(array($strings));
-	else 
+	else
 	{
 		foreach ($strings as &$str)
 		{

--- a/test/HasManyThroughTest.php
+++ b/test/HasManyThroughTest.php
@@ -43,6 +43,10 @@ class HasManyThroughTest extends DatabaseTest
 
 		$venue = Venue::find(1, array('include' => array('hosts')));
 		$this->assert_equals(1, $venue->hosts[0]->id);
+
+    $venue = Venue::find(2, array('include' => array('hosts')));
+    $this->assert_equals(2, $venue->hosts[0]->id);
+    $this->assert_equals(2, count($venue->hosts));
 	}
 
 	public function test_gh107_has_many_though_include_eager_with_namespace()

--- a/test/HasManyThroughTest.php
+++ b/test/HasManyThroughTest.php
@@ -43,10 +43,13 @@ class HasManyThroughTest extends DatabaseTest
 
 		$venue = Venue::find(1, array('include' => array('hosts')));
 		$this->assert_equals(1, $venue->hosts[0]->id);
+    }
 
-    $venue = Venue::find(2, array('include' => array('hosts')));
-    $this->assert_equals(2, $venue->hosts[0]->id);
-    $this->assert_equals(2, count($venue->hosts));
+    public function test_gh229_fix_many_to_many_through_association_using_include()
+    {
+        $venue = Venue::find(2, array('include' => array('hosts')));
+        $this->assert_equals(2, $venue->hosts[0]->id);
+        $this->assert_equals(2, count($venue->hosts));
 	}
 
 	public function test_gh107_has_many_though_include_eager_with_namespace()


### PR DESCRIPTION
Found this to be a BIG issue when you called a model that has a many-to-many association that references a 'through' linking table. Most of the time, you would probably get an empty array when you looked at the returned object.

This update properly sets the through association so you have the included models you would expect to find. 
