### PR TITLE
Changes to avoid 'PHP Notice: Undefined index'

### DIFF
--- a/lib/Model.php
+++ b/lib/Model.php
@@ -555,7 +555,7 @@ class Model
 	 */
 	public function attribute_is_dirty($attribute)
 	{
-		return $this->__dirty && $this->__dirty[$attribute] && array_key_exists($attribute, $this->attributes);
+		return $this->__dirty && isset($this->__dirty[$attribute]) && array_key_exists($attribute, $this->attributes);
 	}
 
 	/**


### PR DESCRIPTION
$this->__dirty[$attribute] throws up PHP Notice: Undefined index if $attribute wasn
t modified. Using isset to avoid this notice.
