### PR TITLE
Composer's autoload mechanism fails to load PHP-ActiveRecord classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,6 @@
         "php": ">=5.3.0"
     },
     "autoload": {
-        "psr-0": {
-            "ActiveRecord": "lib/"
-        }
+        "files": [ "ActiveRecord.php" ]
     }
 }


### PR DESCRIPTION
PHP-ActiveRecord doesn't actually follow PSR-0 convention, e.g. `ActiveRecord\Config` should be in `lib/ActiveRecord/Config.php` and not `lib/Config.php`.  Fortunately, loading the `ActiveRecord.php` file loads the common dependencies and registers an autoloader The Old Fashioned Way, and Composer has a config option for that.
