### PR TITLE
Chain SQL queries

### DIFF
--- a/ActiveRecord.php
+++ b/ActiveRecord.php
@@ -21,6 +21,7 @@ require 'lib/Inflector.php';
 require 'lib/CallBack.php';
 require 'lib/Exceptions.php';
 require 'lib/Cache.php';
+require 'lib/Query.php';
 
 if (!defined('PHP_ACTIVERECORD_AUTOLOAD_DISABLE'))
 	spl_autoload_register('activerecord_autoload',false,PHP_ACTIVERECORD_AUTOLOAD_PREPEND);

--- a/lib/Query.php
+++ b/lib/Query.php
@@ -47,6 +47,14 @@ class Query
   {
     if (in_array($method, self::get_builder_scopes())) 
       return $this->set_option($method, $arguments[0]);
+    elseif (is_callable(array($this->model_name, $method))) 
+    {
+      $query = call_user_func_array(array($this->model_name, $method), $arguments);
+      if (!$query instanceof Query)
+        throw new ActiveRecordException("Scopes must return a Query object");
+
+      return $this->merge($query->get_options());
+    }
     else
       throw new ActiveRecordException("The scope \"$method\" does not exists");
   }
@@ -75,6 +83,17 @@ class Query
   public function readonly($flag = true) 
   {
     $this->options['readonly'] = (boolean) $flag;
+    return $this;
+  }
+
+  /**
+   * Merges the current query with the options in argument. In case of repeated options, the argument predominates
+   */
+  public function merge($options) 
+  {
+    foreach($options as $option => $value) {
+      $this->options[$option] = $value;
+    }
     return $this;
   }
 

--- a/lib/Query.php
+++ b/lib/Query.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * @package ActiveRecord
+ */
+namespace ActiveRecord;
+
+/**
+ * Used to create chain queries and scopes
+ *
+ * @package ActiveRecord
+ */
+class Query
+{
+
+  private $model_name;
+  private $options = array();
+
+  /**
+   * Determinates the valid aliases for the model
+   */
+  private static $builder_scopes = array(
+    'where',
+    'order',
+    'group',
+    'limit',
+    'offset',
+    'select',
+    'having',
+    'include',
+    'joins',
+  );
+
+  public function __construct($model_name) 
+  { 
+    $this->model_name = $model_name;
+  }
+
+  public static function get_builder_scopes()
+  {
+    return self::$builder_scopes;
+  }  
+
+  /**
+   * Sets the normal options
+   */
+  public function __call($method, $arguments) 
+  {
+    if (in_array($method, self::get_builder_scopes())) 
+      return $this->set_option($method, $arguments[0]);
+    else
+      throw new ActiveRecordException("The scope \"$method\" does not exists");
+  }
+
+  public function set_option($option, $value) 
+  {
+    $this->options[$option] = $value;
+    return $this;
+  }
+
+  public function get_options() 
+  {
+    return $this->options;
+  }
+
+  public function where() 
+  {
+    // where is special because of append wheres and overrides. Example:
+    // Model:where(...)->limit(...)->where(...)
+    // Both wheres need to be considered, concatenating them with AND
+    // For while, the while is override
+    $this->options['conditions'] = func_get_args();
+    return $this;
+  }
+
+  public function readonly($flag = true) 
+  {
+    $this->options['readonly'] = (boolean) $flag;
+    return $this;
+  }
+
+  private function find($type = 'all') 
+  {
+    $arguments[] = $type;
+    $options = $this->get_options();    
+    if (!empty($options))
+      $arguments[] = $options;
+
+    return call_user_func_array(array($this->model_name, 'find'), $arguments);
+  }
+
+  /**
+   * Executes the query, returning all the occurences
+   */
+  public function all() 
+  {
+    return $this->find('all');
+  }
+
+  /**
+   * Executes the query, returning the first occurence
+   */
+  public function first() 
+  {
+    return $this->find('first');
+  }
+
+  /**
+   * Executes the query, returning the last occurence
+   */
+  public function last() 
+  {
+    return $this->find('last');
+  }
+
+}

--- a/test/QueryTest.php
+++ b/test/QueryTest.php
@@ -1,0 +1,146 @@
+<?php
+
+include 'helpers/config.php';
+
+class QueryTest extends DatabaseTest
+{
+
+  public function setUp() 
+  {
+    parent::setUp();
+    $this->query = Author::sql();
+  }
+
+  public function test_all() 
+  {
+    $results = $this->query->all(); 
+    $this->assertEquals(4, count($results));
+    foreach($results as $result)
+      $this->assertEquals(Author::find($result->id), $result);
+  }
+
+  public function test_first() 
+  {
+    $result = $this->query->first();
+    $this->assertEquals('Tito', $result->name);
+  }
+
+  public function test_last() 
+  {
+    $result = $this->query->last();
+    $this->assertEquals('Uncle Bob', $result->name);
+  }
+
+  public function test_order() 
+  {
+    $results = $this->query->order('name ASC')->all();
+    $this->assertEquals('Bill Clinton', $results[0]->name);
+  }
+
+  public function test_limit() 
+  {
+    $results = $this->query->order('name ASC')->limit(1)->all();
+    $this->assertEquals(1, count($results));
+  }
+
+  public function test_offset() 
+  {
+    $results = $this->query->order('name DESC')->limit(1)->offset(1)->all();
+    $this->assertEquals('Tito', $results[0]->name);
+  }
+
+  public function test_group() 
+  {
+    $results = $this->query->group('parent_author_id')->all();
+    $this->assertEquals(3, count($results));
+  }
+
+  /**
+   * @expectedException ActiveRecord\UndefinedPropertyException
+   */
+  public function test_select() 
+  {
+    $results = $this->query->select('author_id')->all();
+    $results[0]->name; 
+  }
+
+  public function test_having()
+   {
+    $result = $this->query->having('author_id > 2')->first();
+    $this->assertEquals('Bill Clinton', $result->name);
+  }
+
+  public function test_where_string()
+  {
+    $result = $this->query->where('author_id > 2')->first();
+    $this->assertEquals('Bill Clinton', $result->name);
+  }
+
+  public function test_where_quote() {
+    $result = $this->query->where('name = ?', 'Tito')->first();
+    $this->assertEquals(1, $result->id);
+  }
+
+  public function test_where_hash() {
+    $result = $this->query->where(array('name' => 'Uncle Bob'))->last();
+    $this->assertEquals(4, $result->id);
+  }
+
+  public function test_where_array() {
+    $results = $this->query->where('author_id=? AND name IN(?)',1,array('Tito','Mexican'))->all();
+    $this->assertEquals(1, $results[0]->id);
+    $this->assertEquals(1, count($results));
+  }
+
+  public function test_multiple_wheres() { // Not implemented yet
+    $results = $this->query->where(array('parent_author_id' => 2))->where('author_id > ?', 2)->order('name ASC')->all();
+    //$this->assertEquals('Uncle Bob', $results[0]->name);
+    //$this->assertEquals(1, count($results));
+  }
+
+  /**
+   * @expectedException ActiveRecord\ReadOnlyException
+   */
+  public function test_readonly() 
+  {
+    $result = $this->query->readonly()->first();
+    $result->name = '';
+    $result->save();
+  }  
+
+  public function test_alias_order() 
+  {
+    $this->assertEquals($this->query->order('name ASC')->first(), Author::order('name ASC')->first());
+  }
+
+  public function test_alias_limit() 
+  {
+    $this->assertEquals($this->query->limit(1)->all(), Author::limit(1)->all());
+  }
+  
+  public function test_alias_group() 
+  {
+    $this->assertEquals($this->query->group('parent_author_id')->all(), Author::group('parent_author_id')->all());
+  }
+  
+  public function test_alias_offset() 
+  {
+    $this->assertEquals($this->query->offset(2)->first(), Author::offset(2)->first());
+  }
+
+  public function test_alias_select() 
+  {
+    $this->assertEquals($this->query->select('author_id')->first(), Author::select('author_id')->first());
+  }
+
+  public function test_alias_having() 
+  {
+    $this->assertEquals($this->query->having('author_id > 2')->all(), Author::having('author_id > 2')->all());
+  }
+
+  public function test_alias_where() 
+  {
+    $this->assertEquals($this->query->where('author_id = 1')->all(), Author::where('author_id = 1')->all());
+  }
+
+}

--- a/test/QueryTest.php
+++ b/test/QueryTest.php
@@ -2,6 +2,19 @@
 
 include 'helpers/config.php';
 
+class ScopedAuthor extends Author {
+  static $table_name = 'authors';
+
+  public static function top_three() {
+    return static::limit(3)->order('name ASC');
+  }
+
+  public static function named_like($name) {
+    return static::where('name LIKE ?', '%' . $name . '%');
+  }
+
+};
+
 class QueryTest extends DatabaseTest
 {
 
@@ -141,6 +154,37 @@ class QueryTest extends DatabaseTest
   public function test_alias_where() 
   {
     $this->assertEquals($this->query->where('author_id = 1')->all(), Author::where('author_id = 1')->all());
+  }
+
+  public function test_single_scope() 
+  {
+    $results = ScopedAuthor::top_three()->all();
+    $this->assertEquals(3, count($results));
+    $this->assertEquals('Bill Clinton', $results[0]->name);
+  }
+
+  public function test_single_scope_with_default_scopes() 
+  {
+    $results = ScopedAuthor::offset(1)->top_three()->limit(2)->all();
+    $this->assertEquals(2, count($results));
+    $this->assertEquals('George W. Bush', $results[0]->name);
+  }
+
+  public function test_multiple_scopes() 
+  {
+    $results = ScopedAuthor::top_three()->named_like('b')->all();
+    $this->assertEquals(3, count($results));
+    $this->assertEquals('Bill Clinton', $results[0]->name);
+    $this->assertEquals('George W. Bush', $results[1]->name);
+    $this->assertEquals('Uncle Bob', $results[2]->name);
+  }
+
+  public function test_multiple_scopes_with_default_scopes() 
+  {
+    $results = ScopedAuthor::offset(1)->top_three()->limit(2)->named_like('b')->order('author_id DESC')->all();
+    $this->assertEquals(2, count($results));
+    $this->assertEquals('Bill Clinton', $results[0]->name);
+    $this->assertEquals('George W. Bush', $results[1]->name);
   }
 
 }


### PR DESCRIPTION
This is an implementation idea to support chain SQL select queries like proposed in #145.

I pretend to add scopes, default scopes and aliases like `MyModel::where(...)`, but before it I'd like to discuss with you guys if this is the best way of doing that.

The usage is like:

``` php
MyModel::sql()->where(...)->limit(...)->order(...)->all();
```

What it does is update a SQLBuilder instance and execute it after the all() or first() method in the end of the query.

What do you think?
