### PR TITLE
- added possibility to set the model to use custom validation class

### DIFF
--- a/lib/Config.php
+++ b/lib/Config.php
@@ -58,6 +58,14 @@ class Config extends Singleton
 	 */
 	private $model_directory;
 
+
+	/**
+	 * Contains a Validator object that must impelement a validate() method.
+	 *
+	 * @var object
+	 */
+	private $validator = '\ActiveRecord\Validations';
+
 	/**
 	 * Switch for logging.
 	 *
@@ -260,6 +268,37 @@ class Config extends Singleton
 	public function get_logger()
 	{
 		return $this->logger;
+	}
+
+
+	/**
+	 * Sets the validation object
+	 *
+	 * @param object $validator
+	 * @return void
+	 * @throws ConfigException if Validate object does not implement public validate() and public get_record()
+	 */
+	public function set_validator($validator)
+	{
+		$klass = Reflections::instance()->add($validator)->get($validator);
+
+		if (!$klass->getMethod('validate') || !$klass->getMethod('validate')->isPublic())
+			throw new ConfigException("Validator object must implement a public validate method");
+
+        if (!$klass->getMethod('validate') || !$klass->getMethod('get_record')->isPublic())
+            throw new ConfigException("Validator object must implement a public get_record method");
+
+		$this->validator = $validator;
+	}
+
+		/**
+	 * Returns the validator object
+	 *
+	 * @return object
+	 */
+	public function get_validator()
+	{
+		return $this->validator;
 	}
 
 	/**

--- a/lib/Model.php
+++ b/lib/Model.php
@@ -1039,9 +1039,14 @@ class Model
 	 */
 	private function _validate()
 	{
-		require_once 'Validations.php';
+		$config = Config::instance();
 
-		$validator = new Validations($this);
+		$validator_class = $config->get_validator();
+        if ($validator_class == '\ActiveRecord\Validations')
+            require_once 'Validations.php';
+
+		$validator = new $validator_class($this);
+		
 		$validation_on = 'validation_on_' . ($this->is_new_record() ? 'create' : 'update');
 
 		foreach (array('before_validation', "before_$validation_on") as $callback)


### PR DESCRIPTION
Its possible to set up custom validation class like so:

require_once 'someplace/myvalidatorclass.php'; // optional if autoload got namespace already
$cfg = \ActiveRecord\Config::instance();
$cfg->set_validator('\Appendix\Libraries\Validation');

custom validator class have to implement methods validate and get_record.

We use our own validator, that can validate also custom data, files etc., Don't want to have 2 different ways to validate stuff.
