### PR TITLE
php notice on "attribute_is_dirty" call if attribute is not dirty

### DIFF
--- a/lib/Model.php
+++ b/lib/Model.php
@@ -555,7 +555,7 @@ class Model
 	 */
 	public function attribute_is_dirty($attribute)
 	{
-		return $this->__dirty && $this->__dirty[$attribute] && array_key_exists($attribute, $this->attributes);
+		return $this->__dirty && isset($this->__dirty[$attribute]) && array_key_exists($attribute, $this->attributes);
 	}
 
 	/**

--- a/test/ActiveRecordTest.php
+++ b/test/ActiveRecordTest.php
@@ -482,7 +482,14 @@ class ActiveRecordTest extends DatabaseTest
 		$this->assert_null($author->dirty_attributes());
 		$this->assert_false($author->attribute_is_dirty('some_inexistant_property'));
 	}
-	
+
+	public function test_gh245_dirty_attribute_should_not_raise_php_notice_if_not_dirty()
+	{
+		$event = new Event(array('title' => "Fun"));
+		$this->assert_false($event->attribute_is_dirty('description'));
+		$this->assert_true($event->attribute_is_dirty('title'));
+	}
+
 	public function test_assigning_php_datetime_gets_converted_to_ar_datetime()
 	{
 		$author = new Author();


### PR DESCRIPTION
If we pass a non-dirty attribute to `attribute_is_dirty($attribute)`, it raises a php notice.

Filename: lib/Model.php
Line Number: 558

``` php
return $this->__dirty && $this->__dirty[$attribute] && array_key_exists($attribute, $this->attributes);
```

fix:

``` php
return $this->__dirty && array_key_exists($attribute, $this->__dirty) && array_key_exists($attribute, $this->attributes);
```
