### PR TITLE
Added method Utils::add_irregular for managing irregular names

### DIFF
--- a/lib/Utils.php
+++ b/lib/Utils.php
@@ -362,4 +362,9 @@ class Utils
 	{
 		return preg_replace("/$char+/",$char,$string);
 	}
+
+    public static function add_irregular($singular, $plural)
+    {
+        self::$irregular[$singular] = $plural;
+    }
 }


### PR DESCRIPTION
This pull request adds a new method to the Utils class which allows for the dynamic addition of irregular nouns. This method is for those special cases.

Use case:
We have a table name called "Skus" which would be singularised to "Skus" because the ending of the word was "us". We added the "add_irregular" method to circumvent this issue.
