### PR TITLE
Faster relationships

### DIFF
--- a/lib/Relationship.php
+++ b/lib/Relationship.php
@@ -222,8 +222,6 @@ abstract class AbstractRelationship implements InterfaceRelationship
 		}
 	}
 
-	public static $iterations = 0;
-
 	/**
 	 * Creates a new instance of specified {@link Model} with the attributes pre-loaded.
 	 *


### PR DESCRIPTION
I feel like I should just post the patches since I tend to post the patch right after putting up the issue.

Fix for Related to gh-268.

Essentially this will take the amount of iterations required to populate a result say a lot closer to something like 2N, where N is the number of models + relations loaded, as opposed to N^2.

I created a hash map to store all of the possible relations (`$all_related_with_value`), and instead of looping over every found relation for every found model, it will directly pull the relations from the hash map, which is an instant lookup.

Also since this was an optimization, I also changed `$used_models` to store the hash as and using `array_key_exists` instead of using `in_array()`, as in_array requires php to check every value of the array as opposed to just instantly pulling the value from the hash.
