### PR TITLE
right sqlite datetime format string with test case

### DIFF
--- a/lib/adapters/SqliteAdapter.php
+++ b/lib/adapters/SqliteAdapter.php
@@ -38,6 +38,11 @@ class SqliteAdapter extends Connection
 		return $this->query("SELECT name FROM sqlite_master");
 	}
 
+	public function datetime_to_string($datetime)
+    {
+        return $datetime->format('Y-m-d h:i:s');
+    }
+
 	public function create_column($column)
 	{
 		$c = new Column();

--- a/test/SqliteAdapterTest.php
+++ b/test/SqliteAdapterTest.php
@@ -58,6 +58,12 @@ class SqliteAdapterTest extends AdapterTest
 		$this->assert_true($columns['id']->auto_increment);
 	}
 
+    public function test_datetime_to_string()
+    {
+        $datetime = '2009-01-01 01:01:01';
+        $this->assert_equals($datetime,$this->conn->datetime_to_string(date_create($datetime)));
+    }
+
 	// not supported
 	public function test_connect_with_port() {}
 }


### PR DESCRIPTION
fixed issue https://github.com/kla/php-activerecord/issues/276

PHPUnit results:

```
C:\wamp\bin\php\php5.4.3\php.exe C:\Users\Boris\AppData\Local\Temp\ide-phpunit.php --no-configuration --filter "/::test_datetime_to_string( .*)?$/" SqliteAdapterTest C:\repos\php-activerecord\test\SqliteAdapterTest.php
Testing started at 11:38 ...
(Logging SQL queries disabled, PEAR::Log not found.)
(Cache Tests will be skipped, Memcache not found.)
PHPUnit 3.7.19 by Sebastian Bergmann.



Time: 3 seconds, Memory: 3.25Mb

OK (1 test, 1 assertion)

Process finished with exit code 0
```
