### PR TITLE
Security Issue - All Attributes Accessible/Settable by Mass Assignment

### DIFF
--- a/lib/Model.php
+++ b/lib/Model.php
@@ -177,6 +177,12 @@ class Model
 	 *
 	 * This is the opposite of {@link attr_protected $attr_protected}.
 	 *
+	 * The security implementations of this property are larger than one might expect.
+	 * By default, this is set to have a single null value, so that no attributes are accessible via mass assignment.
+	 * It is strongly suggested to list each property that you'd be comfortable excepting overwrites from in this array.
+	 *
+	 * For more details on the security importance of this property, see {@link https://github.com/kla/php-activerecord/issues/287}
+	 *
 	 * <code>
 	 * class Person extends ActiveRecord\Model {
 	 *   static $attr_accessible = array('first_name','last_name');
@@ -192,7 +198,7 @@ class Model
 	 *
 	 * @var array
 	 */
-	static $attr_accessible = array();
+	static $attr_accessible = array(null);
 
 	/**
 	 * Blacklist of attributes that cannot be mass-assigned.


### PR DESCRIPTION
Last year, a massive security issue was found in **Rails** by a russian programmer, that allowed relationships to be changed and insecure data to be entered.
(for the whole story, go here: https://gist.github.com/peternixey/1978249)

The flaw has since been fixed in Rail's [ActiveRecord, by this commit](https://github.com/rails/rails/commit/06a3a8a458e70c1b6531ac53c57a302b162fd736) and in Laravel's ["Eloquent", with this commit](https://github.com/laravel/framework/commit/314fa7fdf95c729bfab00e4f79263ba8fb69ae4b).

**PHP-ActiveRecord** has the ability to mass assign properties similar to these other ORM's, so it also has the same security vulnerability. After MUCH consideration and debate, it was decided that all attributes should be guarded by default.

This change should be implemented into php-activerecord, or most developers could naively write very insecure apps with this library.
