### PR TITLE
Speed up is_{,in}valid

### DIFF
--- a/lib/Model.php
+++ b/lib/Model.php
@@ -1096,7 +1096,7 @@ class Model
 			return $this->_validate();
 
 		// If validated without errors, then it's valid
-		return empty($this->errors);
+		return $this->errors->is_empty();
 	}
 
 	/**


### PR DESCRIPTION
While utilizing this lib, I have encountered an error with validation of password, because I hashed the confirmation one directly in the `validate` method.
The user is something like:

```
class User extends ... {
private $password_confirm;
public function set_password($pass) {
    $this->assign_attribute('password', static::encrypt($pass));
}
public function validate() {
    $this->password_confirm = static::encrypt(password_confirm);
    if($this->password !== $this->password_confirm)
       $this->errors->add('password', 'Password mismatch');
}
```

And with this kind of code:

```
$user = User::create($params);
if( $user->is_invalid() )
    exit_with_error($user);
```

The if statement will be ALWAYS true. Why? It was not so clear at first blush.
The `create` method call `_validate`, but so do `is_invalid`, rehashing again `password_confirm`!
For my point of view, `is_valid` should only be a check and not a `validate` disguised by check. And so do this commit.
