### PR TITLE
Store primary key column name in lower case

### DIFF
--- a/lib/Table.php
+++ b/lib/Table.php
@@ -425,7 +425,10 @@ class Table
 					$this->pk[] = $c->inflected_name;
 			}
 		}
-		$this->pk = array_map('strtolower', $this->pk); // make sure the primary key is stored in lowercase
+		
+		$this->pk = array_map(function($value) {
+			return Inflector::instance()->variablize($value);
+		}, $this->pk);
 	}
 
 	private function set_table_name()


### PR DESCRIPTION
Often, developers set the column names in different cases for the $primary_key static field in the Model. However, the object for the Model stores column names as lowercase (in $attributes). This causes confusion at times (for example, when checking if "$attributes[$pk]" is set while inserting a new record).

This small bit of code makes sure no matter what case the developer sets his primary key ("myPrimaryKey" or "myprimaryKey"), the key will always be stored in all lowercase ("myprimarykey").
