### PR TITLE
Move require_once out of functions?

### DIFF
--- a/lib/SQLBuilder.php
+++ b/lib/SQLBuilder.php
@@ -291,7 +291,6 @@ class SQLBuilder
 
 	private function apply_where_conditions($args)
 	{
-		require_once 'Expressions.php';
 		$num_args = count($args);
 
 		if ($num_args == 1 && is_hash($args[0]))
@@ -345,7 +344,6 @@ class SQLBuilder
 
 	private function build_insert()
 	{
-		require_once 'Expressions.php';
 		$keys = join(',',$this->quoted_key_names());
 
 		if ($this->sequence)


### PR DESCRIPTION
It's really a minor issue, but having `require_once 'Expressions.php';` inside `build_insert()` and `apply_where_conditions($args)` of SQLBuilder.php seems a little odd, as that requires a stat of Expressions.php everytime those functions are called.  It's a sub-microsecond optimization, but my framework is already running in the sub-microseconds for most requests.  I don't see anything that'd be harmed by letting the autoload handle loading it, or even just moving it to the top of the file, so it's always loaded, but I'm still a little new to the guts of phpActiveRecord.
