### PR TITLE
Allow single table inheritance

### DIFF
--- a/lib/Model.php
+++ b/lib/Model.php
@@ -267,6 +267,20 @@ class Model
 
 		$this->invoke_callback('after_construct',false);
 	}
+	
+	/**
+	 * Returns the name of the class to instantiate
+	 * This is called before a model is created to allow for single-table inheritance
+	 * The returned class name has to be a class that extends the base class
+	 * 
+	 * @param array $data Hash containing the loaded database row that will assigned to the model
+	 * @return String the name of the class to instantiate
+	 */
+	public static function instantiate($data)
+	{
+		return get_called_class();
+	}
+	
 
 	/**
 	 * Magic method which delegates to read_attribute(). This handles firing off getter methods,

--- a/lib/Table.php
+++ b/lib/Table.php
@@ -219,7 +219,14 @@ class Table
 
 		while (($row = $sth->fetch()))
 		{
-			$model = new $this->class->name($row,false,true,false);
+			$class_name = $this->class->name;
+			$class = $class_name::instantiate($row);
+			$model = new $class($row,false,true,false);
+			/* Make sure the returned class inherits from the base class */
+			if(!($model instanceof $this->class->name)) 
+			{
+				throw new ActiveRecordException('Instantiated model needs to inherit from the base class '.$this->class->name);
+			}
 
 			if ($readonly)
 				$model->readonly();

--- a/test/ActiveRecordFindTest.php
+++ b/test/ActiveRecordFindTest.php
@@ -464,5 +464,61 @@ class ActiveRecordFindTest extends DatabaseTest
 		$this->assert_not_null(Author::find_by_created_at($now));
 		$this->assert_not_null(Author::find_by_created_at($arnow));
 	}
+	
+	public function testInstantiatingANormalBook()
+	{
+		$book = new InstantiateBook();
+		$book->name = 'NormalBook';
+		$book->save();
+		$normal = InstantiateBook::find($book->id);
+		$this->assertNotInstanceOf('AwesomeBook',$normal);
+	}
+	
+	public function testInstantiatingAnAwesomeBook()
+	{
+		$book = new InstantiateBook();
+		$book->name = 'AwesomeBook';
+		$book->save();
+		$awesome = InstantiateBook::find($book->id);
+		$this->assertInstanceOf('AwesomeBook',$awesome);
+	}
+	
+	/**
+	 * @expectedException ActiveRecord\ActiveRecordException
+	 */
+	public function testInvalidClassThatDoesNotInheritFromParent()
+	{
+		$book = new InstantiateBook();
+		$book->name = 'NotAwesomeBook';
+		$book->save();
+		InstantiateBook::find($book->id);
+	}
+	
+	public function testFindingAllWithInstantiate()
+	{
+		Book::create(array('name'=>'NormalBook'));
+		Book::create(array('name'=>'AwesomeBook'));
+		Book::create(array('name'=>'AnotherBook'));
+		Book::create(array('name'=>'AwesomeBook'));
+		
+		$all_books = InstantiateBook::all();
+		$found_at_least_one_awesome_book = false;
+		$found_at_least_one_not_awesome_book = false;
+		foreach($all_books as $book)
+		{
+			if($book->name === 'AwesomeBook')
+			{
+				$found_at_least_one_awesome_book = true;
+				$this->assertInstanceOf('AwesomeBook',$book);
+			}
+			else
+			{
+				$found_at_least_one_not_awesome_book = true;
+				$this->assertNotInstanceOf('AwesomeBook',$book);
+			}
+		}
+		$this->assert_true($found_at_least_one_awesome_book);
+		$this->assert_true($found_at_least_one_not_awesome_book);
+	}
 };
 ?>

--- a/test/models/InstantiateBook.php
+++ b/test/models/InstantiateBook.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Any book found with the name "AwesomeBook" will automatically be created as an AwesomeBook
+ * as opposed to an InstantiateBook
+ */
+class InstantiateBook extends ActiveRecord\Model
+{
+	public static $table_name = 'books';
+	
+	public static function instantiate($attributes)
+	{
+		if(isset($attributes['name']))
+		{
+			if($attributes['name'] == 'AwesomeBook')
+				return 'AwesomeBook';
+			elseif($attributes['name'] == 'NotAwesomeBook')
+				return 'InvalidAwesomeBook';
+		}
+		
+		return parent::instantiate($attributes);
+	}
+}
+
+class AwesomeBook extends InstantiateBook
+{
+	public static $table_name = 'books';
+}
+
+class InvalidAwesomeBook extends ActiveRecord\Model
+{
+	public static $table_name = 'books';
+}
+?>


### PR DESCRIPTION
This patch adds single table inheritance the same way that Yii framework goes about it.  
http://www.yiiframework.com/wiki/198/single-table-inheritance.

```
/** Here's what we want */
$book = new Book();
$book->name = 'AwesomeBook';
$book->save();
$awesome = Book::find($book->id);
echo get_class($awesome); #AwesomeBook

$book = new Book();
$book->name = 'NormalBook';
$book->save();
$awesome = Book::find($book->id);
echo get_class($awesome); #Book


/** Here's how it's implemented */
class Book extends ActiveRecord\Model
{
    public static $table_name = 'books';

    /** @return a string representing the class to use */
    public static function instantiate($attributes)
    {
        if(isset($attributes['name']))
        {
            if($attributes['name'] == 'AwesomeBook')
                return 'AwesomeBook';
        }

        return parent::instantiate($attributes);
    }
}

class AwesomeBook extends Book
{
    public static $table_name = 'books';
}
```

I've implemented it as having to return a string instead of a class instance since Model's constructor is the only way to mass assign attributes unguarded unfortunately, and I didn't want to complicate the process of extending the method. `return new Book($data,false,true,false); //Would have to actually worry about hydrating the object within instantiate()`

Preferably it'd work like this, where you can return a model to use with the data, and then have `Table` populate the data.

```
public static function instantiate($attributes)
{
  return new AwesomeBook();
  /** And then have Table worry about pushing the attributes into this particular instance */
}
```

as right now I think the default constructor for Model.php does too much at the moment, as it locks the entire implementation for getting around guarded attributes.

I like this feature because currently I've had to implement this sort of inheritance in this extremely cludgey way (Be prepared to avert your eyes in disgust =P)

```
public static function get_all_fields_as_actual_class()
{
    $fields = self::all(array('order'=>'order_by ASC'));
    foreach($fields as &$field)
    {
        $field = Field_Factory::convert_to_type($field);
    }
    return $fields;
}
/** And another method that I had to add just in case I did not want all of the fields at once */
public function convert_to_child()
{
    return Field_Factory::convert_to_type($this);
}

//So.. everytime I want to use a Field with its specific interfaced behavior.. I have to use it as
// $field = Field::find($id)->convert_to_child();, which is also essentially meaning the class has to be double instantiated in order to use child classes.
```

This change would allow this behavior to be the default and prevent convoluted solutions to this pretty simple inheritance issue.

Thoughts, feelings?  Emotions? =P
