### PR TITLE
Fix: Trigger callbacks on empty create and save

### DIFF
--- a/lib/Model.php
+++ b/lib/Model.php
@@ -848,7 +848,7 @@ class Model
 	{
 		$this->verify_not_readonly('update');
 
-		if ($validate && !$this->_validate())
+		if (($validate && !$this->_validate()) || !$this->invoke_callback('before_update',false))
 			return false;
 
 		if ($this->is_dirty())
@@ -858,14 +858,11 @@ class Model
 			if (empty($pk))
 				throw new ActiveRecordException("Cannot update, no primary key defined for: " . get_called_class());
 
-			if (!$this->invoke_callback('before_update',false))
-				return false;
-
 			$dirty = $this->dirty_attributes();
 			static::table()->update($dirty,$pk);
-			$this->invoke_callback('after_update',false);
 		}
 
+		$this->invoke_callback('after_update',false);
 		return true;
 	}
 

--- a/test/ModelCallbackTest.php
+++ b/test/ModelCallbackTest.php
@@ -93,10 +93,16 @@ class ModelCallbackTest extends DatabaseTest
 		$this->assert_fires(array('before_destroy','after_destroy'),
 			function($model) { $model->delete(); });
 	}
-	
+
+	public function test_gh324_callbacks_should_trigger_on_empty_create()
+	{
+		$this->assert_fires(array('after_create', 'after_save'),
+			function($model) { $model = new Venue(); $model->save(); });
+	}
+
 	public function test_gh324_callbacks_should_trigger_on_empty_save()
 	{
-		$this->assert_fires(array('after_save'),
+		$this->assert_fires(array('after_update', 'after_save'),
 			function($model) { $model = Venue::first(); $model->save(); });
 	}
 }


### PR DESCRIPTION
Previously when saving a model without data the callbacks are not triggered, e.g.:

``` php
$blog_item->update_attributes(array());
```
