### PR TITLE
Identity map feature

### DIFF
--- a/lib/Config.php
+++ b/lib/Config.php
@@ -80,6 +80,13 @@ class Config extends Singleton
 	private $date_format = \DateTime::ISO8601;
 
 	/**
+	 * Switch for identity map.
+	 *
+	 * @var bool
+	 */
+	private $identity_map = false;
+
+	/**
 	 * Allows config initialization using a closure.
 	 *
 	 * This method is just syntatic sugar.
@@ -299,6 +306,27 @@ class Config extends Singleton
 	public function set_cache($url, $options=array())
 	{
 		Cache::initialize($url,$options);
+	}
+
+	/**
+	 * Turn on/off identity map
+	 *
+	 * @param boolean $bool
+	 * @return void
+	 */
+	public function set_identity_map($bool)
+	{
+		$this->identity_map = (bool)$bool;
+	}
+
+	/**
+	 * Return whether or not identity map is on
+	 *
+	 * @return boolean
+	 */
+	public function get_identity_map()
+	{
+		return $this->identity_map;
 	}
 };
 ?>

--- a/lib/IdentityMap.php
+++ b/lib/IdentityMap.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * @package ActiveRecord
+ */
+namespace ActiveRecord;
+
+/**
+ * The model identity map.
+ *
+ * By having an identity map we can store instances of a model
+ * and return them when its identity is matched rather than
+ * querying the database again and creating a new instance for
+ * the same data.
+ */
+class IdentityMap extends Singleton
+{
+	private $_map = array();
+
+
+	public function store(Model $model)
+	{
+		$id = $model->id;
+		$table = $model->table_name();
+
+		$this->_map[$table][$id] = $model;
+	}
+
+
+	public function get($table, $id)
+	{
+		return isset($this->_map[$table][$id]) ? $this->_map[$table][$id] : null;
+	}
+};
+?>

--- a/lib/Model.php
+++ b/lib/Model.php
@@ -1237,7 +1237,19 @@ class Model
 				if (is_null($model))
 					return $this->__relationships[$name] = array();
 				else
+				{
+					// check to see if the model already exists in the relationship array
+					if (isset($this->__relationships[$name]))
+					{
+						foreach ($this->__relationships[$name] as $existing_model)
+						{
+							if ($existing_model === $model)
+								return;
+						}
+					}
+
 					return $this->__relationships[$name][] = $model;
+				}
 			}
 			else
 				return $this->__relationships[$name] = $model;

--- a/lib/Model.php
+++ b/lib/Model.php
@@ -1149,6 +1149,20 @@ class Model
 	}
 
 	/**
+	 * Mass update the model with new data from an attributes hash.
+	 *
+	 * Unlike set_attributes() this method will add new attributes if it doesnt already
+	 * exist in the model attribute hash.
+	 *
+	 * @see set_attributes
+	 * @param array $attributes An array containing data to update in the form array(name => value, ...)
+	 */
+	public function merge_attributes(array $attributes)
+	{
+		$this->set_attributes_via_mass_assignment($attributes, false);
+	}
+
+	/**
 	 * Passing $guard_attributes as true will throw an exception if an attribute does not exist.
 	 *
 	 * @throws ActiveRecord\UndefinedPropertyException

--- a/lib/Relationship.php
+++ b/lib/Relationship.php
@@ -668,6 +668,17 @@ class BelongsTo extends AbstractRelationship
 		foreach ($this->foreign_key as $key)
 			$keys[] = $inflector->variablize($key);
 
+		// the identity map is experimental so it is disabled by default
+		if (Config::instance()->get_identity_map())
+		{
+			// return the existing model instance if its found in the identity map
+			$class = $this->class_name;
+			$pk = $model->get_values_for($keys)[$keys[0]];
+			$ret = IdentityMap::instance()->get($class::table_name(), $pk);
+
+			if ($ret) return $ret;
+		}
+
 		if (!($conditions = $this->create_conditions_from_keys($model, $this->primary_key, $keys)))
 			return null;
 

--- a/lib/Relationship.php
+++ b/lib/Relationship.php
@@ -673,7 +673,8 @@ class BelongsTo extends AbstractRelationship
 		{
 			// return the existing model instance if its found in the identity map
 			$class = $this->class_name;
-			$pk = $model->get_values_for($keys)[$keys[0]];
+			$table_values = $model->get_values_for($keys);
+			$pk = $table_values[$keys[0]];
 			$ret = IdentityMap::instance()->get($class::table_name(), $pk);
 
 			if ($ret) return $ret;

--- a/lib/Table.php
+++ b/lib/Table.php
@@ -221,14 +221,21 @@ class Table
 
 		while (($row = $sth->fetch()))
 		{
+			$model = null;
+
 			// return the existing model instance if its found in the identity map
 			$pk = $this->get_primary_column()->name;
-			$model = IdentityMap::instance()->get($this->table, $row[$pk]);
+			$has_pk = isset($row[$pk]);
+
+			if ($has_pk)
+				$model = IdentityMap::instance()->get($this->table, $row[$pk]);
 			
 			if (!$model)
 			{
 				$model = new $this->class->name($row,false,true,false);
-				IdentityMap::instance()->store($model);
+
+				if ($has_pk)
+					IdentityMap::instance()->store($model);
 
 				if ($readonly)
 					$model->readonly();

--- a/lib/Table.php
+++ b/lib/Table.php
@@ -224,7 +224,7 @@ class Table
 			$model = null;
 
 			// return the existing model instance if its found in the identity map
-			$pk = $this->get_primary_column()->name;
+			$pk = $this->get_primary_column()->inflected_name;
 			$has_pk = isset($row[$pk]);
 
 			if ($has_pk)
@@ -243,6 +243,8 @@ class Table
 				if ($collect_attrs_for_includes)
 					$attrs[] = $model->attributes();
 			}
+			else
+				$model->merge_attributes($row);
 
 			$list[] = $model;
 		}

--- a/lib/Table.php
+++ b/lib/Table.php
@@ -250,7 +250,12 @@ class Table
 					$attrs[] = $model->attributes();
 			}
 			else
+			{
 				$model->merge_attributes($row); // update the existing model instance
+				
+				if ($collect_attrs_for_includes)
+					$attrs[] = $model->attributes();
+			}
 
 			$list[] = $model;
 		}

--- a/lib/Table.php
+++ b/lib/Table.php
@@ -223,18 +223,24 @@ class Table
 		{
 			$model = null;
 
-			// return the existing model instance if its found in the identity map
-			$pk = $this->get_primary_column()->inflected_name;
-			$has_pk = isset($row[$pk]);
+			// the identity map is experimental so it is disabled by default
+			if (Config::instance()->get_identity_map())
+			{
+				// get the primary key if it has been selected
+				$pk = $this->get_primary_column()->inflected_name;
+				$has_pk = isset($row[$pk]);
 
-			if ($has_pk)
-				$model = IdentityMap::instance()->get($this->table, $row[$pk]);
+				// return the existing model instance if its found in the identity map
+				if ($has_pk)
+					$model = IdentityMap::instance()->get($this->table, $row[$pk]);
+			}
 			
+			// create model if identity map is disabled or the record hasnt been retrieved yet
 			if (!$model)
 			{
 				$model = new $this->class->name($row,false,true,false);
 
-				if ($has_pk)
+				if (Config::instance()->get_identity_map() && $has_pk)
 					IdentityMap::instance()->store($model);
 
 				if ($readonly)
@@ -244,7 +250,7 @@ class Table
 					$attrs[] = $model->attributes();
 			}
 			else
-				$model->merge_attributes($row);
+				$model->merge_attributes($row); // update the existing model instance
 
 			$list[] = $model;
 		}

--- a/test/IdentityMapTest.php
+++ b/test/IdentityMapTest.php
@@ -14,4 +14,18 @@ class IdentityMapTest extends DatabaseTest
 
 		$this->assert_equals($author1->name, $author2->name);
 	}
+
+
+	public function test_same_instance_returned_in_relationships()
+	{
+		$host1 = Host::find(1);
+		$event = $host1->events[0];
+		$host2 = $event->host;
+
+		$this->assert_equals($host1->name, $host2->name);
+
+		$host1->name = "New Host Name";
+
+		$this->assert_equals($host1->name, $host2->name);
+	}
 }

--- a/test/IdentityMapTest.php
+++ b/test/IdentityMapTest.php
@@ -3,6 +3,19 @@ include 'helpers/config.php';
 
 class IdentityMapTest extends DatabaseTest
 {
+	public function set_up($connection_name = NULL)
+	{
+		parent::set_up($connection_name);
+		ActiveRecord\Config::instance()->set_identity_map(true);
+	}
+
+	public function tear_down()
+	{
+		ActiveRecord\Config::instance()->set_identity_map(false);
+		parent::tear_down();
+	}
+
+
 	public function test_persistence_between_model_instances()
 	{
 		$author1 = Author::find(1);

--- a/test/IdentityMapTest.php
+++ b/test/IdentityMapTest.php
@@ -59,4 +59,10 @@ class IdentityMapTest extends DatabaseTest
 		$this->assert_contains('state', array_keys($venue1->attributes()));
 		$this->assert_contains('phone', array_keys($venue1->attributes()));
 	}
+
+
+	public function test_relationships_return_existing_instance()
+	{
+		
+	}
 }

--- a/test/IdentityMapTest.php
+++ b/test/IdentityMapTest.php
@@ -28,4 +28,22 @@ class IdentityMapTest extends DatabaseTest
 
 		$this->assert_equals($host1->name, $host2->name);
 	}
+
+
+	public function test_fill_in_missing_attributes()
+	{
+		$venue1 = Venue::find(1, array('select' => 'id, name'));
+
+		$this->assert_equals(2, count($venue1->attributes()));
+		$this->assert_contains('id', array_keys($venue1->attributes()));
+		$this->assert_contains('name', array_keys($venue1->attributes()));
+
+		$venue2 = Venue::find(1, array('select' => 'id, state, phone'));
+		
+		$this->assert_equals(4, count($venue1->attributes()));
+		$this->assert_contains('id', array_keys($venue1->attributes()));
+		$this->assert_contains('name', array_keys($venue1->attributes()));
+		$this->assert_contains('state', array_keys($venue1->attributes()));
+		$this->assert_contains('phone', array_keys($venue1->attributes()));
+	}
 }

--- a/test/IdentityMapTest.php
+++ b/test/IdentityMapTest.php
@@ -1,0 +1,17 @@
+<?php 
+include 'helpers/config.php';
+
+class IdentityMapTest extends DatabaseTest
+{
+	public function test_persistence_between_model_instances()
+	{
+		$author1 = Author::find(1);
+		$author2 = Author::find(1);
+
+		$this->assert_equals($author1->name, $author2->name);
+
+		$author1->name = 'A New Title';
+
+		$this->assert_equals($author1->name, $author2->name);
+	}
+}

--- a/test/IdentityMapTest.php
+++ b/test/IdentityMapTest.php
@@ -61,8 +61,42 @@ class IdentityMapTest extends DatabaseTest
 	}
 
 
-	public function test_relationships_return_existing_instance()
+	public function test_relationship_belongs_to()
 	{
-		
+		$author = Author::find(1);
+		$book = Book::find(1);
+
+		$this->assert_same($author, $book->author);
+	}
+
+
+	public function test_relationship_has_many()
+	{
+		$author = Author::find(1);
+		$book = Book::find(1);
+		$books = $author->books;
+
+		$this->assert_equals(1, count($books));
+		$this->assert_same($book, $books[0]);
+	}
+
+
+	public function test_eager_load_belongs_to()
+	{
+		$book = Book::find(1, array('include' => array('author')));
+		$author = Author::find(1);
+
+		$this->assert_same($author, $book->author);
+	}
+
+
+	public function test_eager_load_has_many()
+	{
+		$author1 = Author::find(1, array('include' => array('books')));
+		$author2 = Author::find(1, array('include' => array('books')));
+		$book = Book::find(1);
+
+		$this->assert_equals(1, count($author1->books));
+		$this->assert_same($book, $author1->books[0]);
 	}
 }


### PR DESCRIPTION
This is related to the proposed feature pull request https://github.com/kla/php-activerecord/pull/321

It adds basic support for identity maps, enough to pass the suggested test. It currently does this in the table::find_by_sql function using the IdentityMap singleton to retrieve and store the model instances based on their table name and primary key.

Please do review it and suggest changes. I'll be adding in support for the identity map in eager loading as well as find_by_pk queries so it doesnt need to hit the database either.
