### PR TITLE
registering multi-mdoel-directory

### DIFF
--- a/ActiveRecord.php
+++ b/ActiveRecord.php
@@ -24,17 +24,29 @@ require __DIR__.'/lib/Cache.php';
 
 if (!defined('PHP_ACTIVERECORD_AUTOLOAD_DISABLE'))
 	spl_autoload_register('activerecord_autoload',false,PHP_ACTIVERECORD_AUTOLOAD_PREPEND);
-
+/**
+ * @author Editted by Dariush Hasanpoor <b.g.dariush@gmail.com>
+ */
 function activerecord_autoload($class_name)
 {
-	$path = ActiveRecord\Config::instance()->get_model_directory();
-	$root = realpath(isset($path) ? $path : '.');
-
+        $path = ActiveRecord\Config::instance()->get_model_directory();
+        
+        // this was editted from original version
+        $root = realpath('.');
+        // this is written to handle multi model directory loading
+        foreach (explode(PATH_SEPARATOR, $path) as $key => $value)
+        {
+            if(file_exists("$value/$class_name.php"))
+            {
+                $root = $value;
+                break;
+            }
+        }
+        
 	if (($namespaces = ActiveRecord\get_namespaces($class_name)))
 	{
 		$class_name = array_pop($namespaces);
 		$directories = array();
-
 		foreach ($namespaces as $directory)
 			$directories[] = $directory;
 

--- a/lib/Config.php
+++ b/lib/Config.php
@@ -190,27 +190,36 @@ class Config extends Singleton
 	}
 
 	/**
-	 * Sets the directory where models are located.
-	 *
+	 * Sets directories where models are located.
 	 * @param string $dir Directory path containing your models
 	 * @return void
+         * @author Editted by Dariush Hasanpoor <b.g.dariush@gmail.com>
 	 */
 	public function set_model_directory($dir)
 	{
-		$this->model_directory = $dir;
+            if(!$this->model_directory)
+            {
+                $this->model_directory = $dir;
+                return;
+            }
+            // if it is not already registered, do:
+            if(strpos($this->model_directory, $dir)===false)
+                $this->model_directory = implode(PATH_SEPARATOR, array($this->model_directory, $dir));
 	}
 
 	/**
-	 * Returns the model directory.
+	 * Returns model directories.
 	 *
 	 * @return string
-	 * @throws ConfigException if specified directory was not found
+         * @author Editted by Dariush Hasanpoor <b.g.dariush@gmail.com>
 	 */
 	public function get_model_directory()
 	{
-		if ($this->model_directory && !file_exists($this->model_directory))
+                // we don't realy want to check directory models file existance because it is 
+                // a combined path.
+		if (false && $this->model_directory && !file_exists($this->model_directory))
 			throw new ConfigException('Invalid or non-existent directory: '.$this->model_directory);
-
+                
 		return $this->model_directory;
 	}
 


### PR DESCRIPTION
The tiny changes that has been made now every the programmer is able to set multi-model-directory

for example every time that developer call the following function at \ActiveRecord\Config::initialize(function($cfg){}) function :
- $cfg->set_model_directory($another_db_model_path);

the $another_db_model_path will be added to model directory string and in autoloading this directory will be consider when trying to locate mdoles' directory

NOTE: this comes realy helpfull when developers are working with multi module application and in modules they get access and use other modules' Models too.
