### PR TITLE
Fixing issue with eager load, through and class_name

### DIFF
--- a/lib/Relationship.php
+++ b/lib/Relationship.php
@@ -156,17 +156,12 @@ abstract class AbstractRelationship implements InterfaceRelationship
 			$this->set_keys($this->get_table()->class->getName(), true);
 
 			if (!isset($options['class_name'])) {
-				$class = classify($options['through'], true);
-				if (isset($this->options['namespace']) && !class_exists($class))
-					$class = $this->options['namespace'].'\\'.$class;
-
-				$through_table = $class::table();
+				$relation = $table->get_relationship($options['through'], true);
 			} else {
 				$class = $options['class_name'];
 				$relation = $class::table()->get_relationship($options['through']);
-				$through_table = $relation->get_table();
 			}
-			$options['joins'] = $this->construct_inner_join_sql($through_table, true);
+			$options['joins'] = $this->construct_inner_join_sql($relation->get_table(), true);
 
 			$query_key = $this->primary_key[0];
 


### PR DESCRIPTION
Fixing problem on eager loading where relationships that went through an other relationship that had a custom class_name would not load the correct class
