### PR TITLE
Fix PgsqlAdapter native types, default values.

### DIFF
--- a/lib/adapters/PgsqlAdapter.php
+++ b/lib/adapters/PgsqlAdapter.php
@@ -101,7 +101,7 @@ SQL;
 
 		$c->map_raw_type();
 
-		if ($column['default'] !== NULL)
+		if (!is_null($column['default']))
 		{
 			preg_match("/^nextval\('(.*)'\)$/",$column['default'],$matches);
 


### PR DESCRIPTION
- The native types array were missing 'real','bigint','smallint', 'double precision', 'decimal' and 'numeric'.  See: http://www.postgresql.org/docs/9.1/static/datatype-numeric.html
- Both 0 and the empty string "" are valid defaults but were not being recognized.  Changed to check explicitly for NULL defaults.
