### PR TITLE
Allows for aliased methods in serialization

### DIFF
--- a/lib/Serialization.php
+++ b/lib/Serialization.php
@@ -136,10 +136,13 @@ abstract class Serialization
 		{
 			$this->options_to_a('methods');
 
-			foreach ($this->options['methods'] as $method)
+			foreach ($this->options['methods'] as $method => $name)
 			{
+				if (is_numeric($method))
+					$method = $name;
+
 				if (method_exists($this->model, $method))
-					$this->attributes[$method] = $this->model->$method();
+					$this->attributes[$name] = $this->model->$method();
 			}
 		}
 	}


### PR DESCRIPTION
So we can do stuff like `$model->to_array(['methods' => ['get_name' => 'name']]);`
