### PR TITLE
Adding the Serialization class file in list of required files

### DIFF
--- a/ActiveRecord.php
+++ b/ActiveRecord.php
@@ -15,6 +15,7 @@ require __DIR__.'/lib/Model.php';
 require __DIR__.'/lib/Table.php';
 require __DIR__.'/lib/ConnectionManager.php';
 require __DIR__.'/lib/Connection.php';
+require __DIR__.'/lib/Serialization.php';
 require __DIR__.'/lib/SQLBuilder.php';
 require __DIR__.'/lib/Reflections.php';
 require __DIR__.'/lib/Inflector.php';


### PR DESCRIPTION
Adding the Serialization class file in the horrible so-called "autoload" file, as it is required if one is ever needing to do Serialization customizations, such as changing the default date format.
