### PR TITLE
Allow custom setter methods to run for aliased attributes (fixes #350)

### DIFF
--- a/lib/Model.php
+++ b/lib/Model.php
@@ -399,7 +399,7 @@ class Model
 		if (array_key_exists($name, static::$alias_attribute))
 			$name = static::$alias_attribute[$name];
 
-		elseif (method_exists($this,"set_$name"))
+		if (method_exists($this,"set_$name"))
 		{
 			$name = "set_$name";
 			return $this->$name($value);

--- a/test/ActiveRecordTest.php
+++ b/test/ActiveRecordTest.php
@@ -259,6 +259,22 @@ class ActiveRecordTest extends DatabaseTest
 		$this->assert_equals($venue->marquee, $venue->name);
 	}
 
+	public function test_alias_attribute_custom_setter()
+	{
+		Venue::$use_custom_set_city_setter = true;
+		$venue = Venue::find(1);
+
+		$venue->mycity = 'cityname';
+		$this->assert_equals($venue->mycity, 'cityname#');
+		$this->assert_equals($venue->mycity, $venue->city);
+
+		$venue->city = 'anothercity';
+		$this->assert_equals($venue->city, 'anothercity#');
+		$this->assert_equals($venue->city, $venue->mycity);
+
+		Venue::$use_custom_set_city_setter = false;
+	}
+
 	public function test_alias_from_mass_attributes()
 	{
 		$venue = new Venue(array('marquee' => 'meme', 'id' => 123));

--- a/test/models/Venue.php
+++ b/test/models/Venue.php
@@ -4,6 +4,7 @@ class Venue extends ActiveRecord\Model
 	static $use_custom_get_state_getter = false;
 	static $use_custom_set_state_setter = false;
 	
+	static $use_custom_set_city_setter = false;
 	
 	static $has_many = array(
 		'events',
@@ -31,6 +32,14 @@ class Venue extends ActiveRecord\Model
 			return $this->assign_attribute('state', $value . '#');
 		else
 			return $this->assign_attribute('state', $value);
+	}
+
+	public function set_city($value)
+	{
+		if (self::$use_custom_set_city_setter)
+			return $this->assign_attribute('city', $value . '#');
+		else
+			return $this->assign_attribute('city', $value);
 	}
 	
 };


### PR DESCRIPTION
The logic in the Model::__set() magic method allowed for either an aliased
attribute _or_ a custom setter, but not both.  If a custom setter method
was defined for an aliased attribute, then the attribute value would be
set without going through the custom setter method.

Changed the logic so that the _set() method first normalizes an
aliased attribute into the real attribute name, then checks to see if
an there is a custom setter method defined and runs it if it exists.
