### PR TITLE
Add query profiling and logging.

### DIFF
--- a/lib/Connection.php
+++ b/lib/Connection.php
@@ -323,7 +323,7 @@ abstract class Connection
 			throw new DatabaseException($e);
 		}
 
-        if ($this->logging) {
+		if ($this->logging) {
 			$time = microtime(true) - $start;
 
 			if ($values) {


### PR DESCRIPTION
Adds both query profiling (#133) and logging of reconstructed SQL query. Current logger writes the prepared query and values separately. After this patch logger reconstructs the prepared query to actual SQL before logging it. Log entry is written as single line. This enables you to use command line tools such as grep when debugging.

This patch is based on Yoan Blancs [ghh133-profiling](https://github.com/greut/php-activerecord/compare/gh133-profiling) branch. Main differences are reconstructing the query and not altering the exception handling.

**Example of log entry with the original logger:**

``` sql
2013-09-28 16:44:25 ident [info] INSERT INTO `venues`(`id`,`name`,`city`,`state`,`address`,`phone`) VALUES(?,?,?,?,?,?)
2013-09-28 16:44:25 ident [info] array (
  0 => '6',
  1 => 'The Note - West Chester',
  2 => 'West Chester',
  3 => 'PA',
  4 => '142 E. Market St.',
  5 => '0000000000',
)
```

**Same entry with the new logger:**

``` sql
2013-09-29 19:46:31 ident [info] INSERT INTO `venues`(`id`,`name`,`city`,`state`,`address`,`phone`) VALUES('6','The Note - West Chester','West Chester','PA','142 E. Market St.','0000000000') -- 0.001
```
