### PR TITLE
Honor primary_key option in $belongs_to

### DIFF
--- a/lib/Relationship.php
+++ b/lib/Relationship.php
@@ -683,6 +683,9 @@ class HasAndBelongsToMany extends AbstractRelationship
  */
 class BelongsTo extends AbstractRelationship
 {
+	
+	static protected $valid_association_options = array('primary_key');
+	
 	public function __construct($options=array())
 	{
 		parent::__construct($options);
@@ -693,6 +696,9 @@ class BelongsTo extends AbstractRelationship
 		//infer from class_name
 		if (!$this->foreign_key)
 			$this->foreign_key = array(Inflector::instance()->keyify($this->class_name));
+	
+		if (!isset($this->primary_key) && isset($this->options['primary_key']))
+			$this->primary_key = is_array($this->options['primary_key']) ? $this->options['primary_key'] : array($this->options['primary_key']);
 	}
 
 	public function __get($name)


### PR DESCRIPTION
Fixes #364 primary_key support when using [belongs_to](http://www.phpactiverecord.org/projects/main/wiki/Associations#belongs_to) relationship. With the following code:

``` php
class Car extends ActiveRecord\Model {
    static $belongs_to = array(
        array("alarm", "foreign_key" => "slug", "primary_key" => "slug")
    );
}

var_dump(Car::find($id)->alarm);
```

generated query before the patch is:

``` sql
SELECT * FROM `alarms` WHERE `id`='something' LIMIT 0,1
```

after the patch it will be:

``` sql
SELECT * FROM `alarms` WHERE `slug`='something' LIMIT 0,1
```
