### PR TITLE
Honor primary_key option in $has_many when eager loading.

### DIFF
--- a/lib/Relationship.php
+++ b/lib/Relationship.php
@@ -602,7 +602,7 @@ class HasMany extends AbstractRelationship
 	public function load_eagerly($models=array(), $attributes=array(), $includes, Table $table)
 	{
 		$this->set_keys($table->class->name);
-		$this->query_and_attach_related_models_eagerly($table,$models,$attributes,$includes,$this->foreign_key, $table->pk);
+		$this->query_and_attach_related_models_eagerly($table,$models,$attributes,$includes,$this->foreign_key, $this->primary_key);
 	}
 };
 


### PR DESCRIPTION
Fixes #366 primary_key support when using has_many relationship and eager loading. 

With the following code:

``` php
class Car extends ActiveRecord\Model {
  static $has_many = array(
      array("residual_values", "foreign_key" => "slug", "primary_key" => "slug")
  );
}

$foo = Car::find($id)->residual_values;

$bar = Car::find($id, array(
    "include" => array("residual_values")
));
```

generated query before the patch is:

``` sql
SELECT * FROM `residual_values` WHERE `slug`='something'
SELECT * FROM `residual_values` WHERE `slug` IN(119)
```

after the patch it will be:

``` sql
SELECT * FROM `residual_values` WHERE `slug`='something'
SELECT * FROM `residual_values` WHERE `slug`='something'
```
