### PR TITLE
A bug fix on delete_all() with no condition

### DIFF
--- a/lib/Model.php
+++ b/lib/Model.php
@@ -909,7 +909,7 @@ class Model
 		$conn = static::connection();
 		$sql = new SQLBuilder($conn, $table->get_fully_qualified_table_name());
 
-		$conditions = is_array($options) ? $options['conditions'] : $options;
+		$conditions = is_array($options) ? isset($options['conditions'])?$options['conditions']:NULL : $options;
 
 		if (is_array($conditions) && !is_hash($conditions))
 			call_user_func_array(array($sql, 'delete'), $conditions);


### PR DESCRIPTION
## If you use delete() all without any conditions the error like bellow will raise:
## Notice: Undefined index: conditions in /var/www/../activeRecord/../Model.php on line 912

this commit will fix that
