### PR TITLE
Removed trailing closing PHP tags "?>"

### DIFF
--- a/ActiveRecord.php
+++ b/ActiveRecord.php
@@ -47,4 +47,3 @@ function activerecord_autoload($class_name)
 	if (file_exists($file))
 		require_once $file;
 }
-?>

--- a/lib/Cache.php
+++ b/lib/Cache.php
@@ -77,4 +77,3 @@ class Cache
 		return (isset(static::$options['namespace']) && strlen(static::$options['namespace']) > 0) ? (static::$options['namespace'] . "::") : "";
 	}
 }
-?>

--- a/lib/CallBack.php
+++ b/lib/CallBack.php
@@ -249,4 +249,3 @@ class CallBack
 			$this->registry[$name][] = $closure_or_method_name;
 	}
 }
-?>

--- a/lib/Column.php
+++ b/lib/Column.php
@@ -152,4 +152,3 @@ class Column
 		return $this->type;
 	}
 }
-?>

--- a/lib/Config.php
+++ b/lib/Config.php
@@ -300,5 +300,4 @@ class Config extends Singleton
 	{
 		Cache::initialize($url,$options);
 	}
-};
-?>
+}

--- a/lib/Connection.php
+++ b/lib/Connection.php
@@ -531,6 +531,3 @@ abstract class Connection
 	}
 
 }
-
-;
-?>

--- a/lib/ConnectionManager.php
+++ b/lib/ConnectionManager.php
@@ -47,5 +47,3 @@ class ConnectionManager extends Singleton
 			unset(self::$connections[$name]);
 	}
 }
-
-?>

--- a/lib/DateTime.php
+++ b/lib/DateTime.php
@@ -148,4 +148,3 @@ class DateTime extends \DateTime
 		call_user_func_array(array($this,'parent::setTimestamp'),func_get_args());
 	}
 }
-?>

--- a/lib/Exceptions.php
+++ b/lib/Exceptions.php
@@ -9,14 +9,14 @@ namespace ActiveRecord;
  *
  * @package ActiveRecord
  */
-class ActiveRecordException extends \Exception {};
+class ActiveRecordException extends \Exception {}
 
 /**
  * Thrown when a record cannot be found.
  *
  * @package ActiveRecord
  */
-class RecordNotFound extends ActiveRecordException {};
+class RecordNotFound extends ActiveRecordException {}
 
 /**
  * Thrown when there was an error performing a database operation.
@@ -44,28 +44,28 @@ class DatabaseException extends ActiveRecordException
 		else
 			parent::__construct($adapter_or_string_or_mystery);
 	}
-};
+}
 
 /**
  * Thrown by {@link Model}.
  *
  * @package ActiveRecord
  */
-class ModelException extends ActiveRecordException {};
+class ModelException extends ActiveRecordException {}
 
 /**
  * Thrown by {@link Expressions}.
  *
  * @package ActiveRecord
  */
-class ExpressionsException extends ActiveRecordException {};
+class ExpressionsException extends ActiveRecordException {}
 
 /**
  * Thrown for configuration problems.
  *
  * @package ActiveRecord
  */
-class ConfigException extends ActiveRecordException {};
+class ConfigException extends ActiveRecordException {}
 
 /**
  * Thrown when attempting to access an invalid property on a {@link Model}.
@@ -91,7 +91,7 @@ class UndefinedPropertyException extends ModelException
 		$this->message = "Undefined property: {$class_name}->{$property_name} in {$this->file} on line {$this->line}";
 		parent::__construct();
 	}
-};
+}
 
 /**
  * Thrown when attempting to perform a write operation on a {@link Model} that is in read-only mode.
@@ -112,26 +112,25 @@ class ReadOnlyException extends ModelException
 		$this->message = "{$class_name}::{$method_name}() cannot be invoked because this model is set to read only";
 		parent::__construct();
 	}
-};
+}
 
 /**
  * Thrown for validations exceptions.
  *
  * @package ActiveRecord
  */
-class ValidationsArgumentError extends ActiveRecordException {};
+class ValidationsArgumentError extends ActiveRecordException {}
 
 /**
  * Thrown for relationship exceptions.
  *
  * @package ActiveRecord
  */
-class RelationshipException extends ActiveRecordException {};
+class RelationshipException extends ActiveRecordException {}
 
 /**
  * Thrown for has many thru exceptions.
  *
  * @package ActiveRecord
  */
-class HasManyThroughAssociationException extends RelationshipException {};
-?>
+class HasManyThroughAssociationException extends RelationshipException {}

--- a/lib/Expressions.php
+++ b/lib/Expressions.php
@@ -182,4 +182,3 @@ class Expressions
 		return "'" . str_replace("'","''",$value) . "'";
 	}
 }
-?>

--- a/lib/Inflector.php
+++ b/lib/Inflector.php
@@ -117,4 +117,3 @@ class StandardInflector extends Inflector
 	public function tableize($s) { return Utils::pluralize(strtolower($this->underscorify($s))); }
 	public function variablize($s) { return str_replace(array('-',' '),array('_','_'),strtolower(trim($s))); }
 }
-?>

--- a/lib/Model.php
+++ b/lib/Model.php
@@ -1858,5 +1858,4 @@ class Model
 		}
 		return true;
 	}
-};
-?>
+}

--- a/lib/Reflections.php
+++ b/lib/Reflections.php
@@ -83,4 +83,3 @@ class Reflections extends Singleton
 		return $this->get_called_class();
 	}
 }
-?>

--- a/lib/Relationship.php
+++ b/lib/Relationship.php
@@ -380,7 +380,7 @@ abstract class AbstractRelationship implements InterfaceRelationship
 	 * @param Model $model The model this relationship belongs to
 	 */
 	abstract function load(Model $model);
-};
+}
 
 /**
  * One-to-many relationship.
@@ -604,7 +604,7 @@ class HasMany extends AbstractRelationship
 		$this->set_keys($table->class->name);
 		$this->query_and_attach_related_models_eagerly($table,$models,$attributes,$includes,$this->foreign_key, $table->pk);
 	}
-};
+}
 
 /**
  * One-to-one relationship.
@@ -626,7 +626,7 @@ class HasMany extends AbstractRelationship
  */
 class HasOne extends HasMany
 {
-};
+}
 
 /**
  * @todo implement me
@@ -650,7 +650,7 @@ class HasAndBelongsToMany extends AbstractRelationship
 	{
 
 	}
-};
+}
 
 /**
  * Belongs to relationship.
@@ -725,5 +725,4 @@ class BelongsTo extends AbstractRelationship
 	{
 		$this->query_and_attach_related_models_eagerly($table,$models,$attributes,$includes, $this->primary_key,$this->foreign_key);
 	}
-};
-?>
+}

--- a/lib/SQLBuilder.php
+++ b/lib/SQLBuilder.php
@@ -420,4 +420,3 @@ class SQLBuilder
 		return $keys;
 	}
 }
-?>

--- a/lib/Serialization.php
+++ b/lib/Serialization.php
@@ -369,4 +369,3 @@ class CsvSerializer extends Serialization
     return $buffer;
   }
 }
-?>

--- a/lib/Singleton.php
+++ b/lib/Singleton.php
@@ -54,4 +54,3 @@ abstract class Singleton
 		return get_class($backtrace[2]['object']);
 	}
 }
-?>

--- a/lib/Table.php
+++ b/lib/Table.php
@@ -551,5 +551,4 @@ class Table
 			trigger_error('static::$getters and static::$setters are deprecated. Please define your setters and getters by declaring methods in your model prefixed with get_ or set_. See
 			http://www.phpactiverecord.org/projects/main/wiki/Utilities#attribute-setters and http://www.phpactiverecord.org/projects/main/wiki/Utilities#attribute-getters on how to make use of this option.', E_USER_DEPRECATED);
 	}
-};
-?>
+}

--- a/lib/Utils.php
+++ b/lib/Utils.php
@@ -362,5 +362,4 @@ class Utils
 	{
 		return preg_replace("/$char+/",$char,$string);
 	}
-};
-?>
+}

--- a/lib/Validations.php
+++ b/lib/Validations.php
@@ -908,5 +908,4 @@ class Errors implements IteratorAggregate
 	{
 		return new ArrayIterator($this->full_messages());
 	}
-};
-?>
+}


### PR DESCRIPTION
It's a good practice to remove the closing PHP tags to prevent empty lines printed before the header of the HTML.
