### PR TITLE
Avoid duplicate foreign_key values when do eager loading (preloading)

### DIFF
--- a/lib/Relationship.php
+++ b/lib/Relationship.php
@@ -137,7 +137,7 @@ abstract class AbstractRelationship implements InterfaceRelationship
 		foreach ($attributes as $column => $value)
 			$values[] = $value[$inflector->variablize($model_values_key)];
 
-		$values = array($values);
+		$values = array(array_unique($values));
 		$conditions = SQLBuilder::create_conditions_from_underscored_string($table->conn,$query_key,$values);
 
 		if (isset($options['conditions']) && strlen($options['conditions'][0]) > 1)


### PR DESCRIPTION
Example:

```
$posts = Post::all(array('include' => array('author'));

foreach($posts as $post){
    echo $post->author->name;
}
```

After loading the posts, It will collect the _author_id_ from each one and load all the referenced authors with one query.

But some posts may have the same _author_id_ so we should avoid them being duplicated (in select query).
