### PR TITLE
Bugfix - Bigint cast

### DIFF
--- a/lib/Column.php
+++ b/lib/Column.php
@@ -121,25 +121,24 @@ class Column
 	 */
 	public static function castIntegerSafely($value)
 	{
-		if (is_int($value)) {
+		if (is_int($value))
 			return $value;
-		}
+
 		// Its just a decimal number
-		elseif (is_numeric($value) && floor($value) != $value) {
+		elseif (is_numeric($value) && floor($value) != $value)
 			return (int) $value;
-		}
+
 		// If adding 0 to a string causes a float conversion,
 		// we have a number over PHP_INT_MAX
-		elseif (is_string($value) && is_float($value + 0)) {
+		elseif (is_string($value) && is_float($value + 0))
 			return (string) $value;
-		}
+
 		// If a float was passed and its greater than PHP_INT_MAX
 		// (which could be wrong due to floating point precision)
 		// We'll also check for equal to (>=) in case the precision
 		// loss creates an overflow on casting
-		elseif (is_float($value) && $value >= PHP_INT_MAX) {
+		elseif (is_float($value) && $value >= PHP_INT_MAX)
 			return number_format($value, 0, '', '');
-		}
 
 		return (int) $value;
 	}

--- a/test/ColumnTest.php
+++ b/test/ColumnTest.php
@@ -90,12 +90,11 @@ class ColumnTest extends SnakeCase_PHPUnit_Framework_TestCase
 		$this->assert_cast(Column::INTEGER,'18446744073709551615','18446744073709551615');
 
 		// 32 bit
-		if (PHP_INT_SIZE === 4) {
+		if (PHP_INT_SIZE === 4)
 			$this->assert_cast(Column::INTEGER,'2147483648',(((float) PHP_INT_MAX) + 1));
 		// 64 bit
-		} elseif (PHP_INT_SIZE === 8) {
+		elseif (PHP_INT_SIZE === 8)
 			$this->assert_cast(Column::INTEGER,'9223372036854775808',(((float) PHP_INT_MAX) + 1));
-		}
 	}
 
 	public function test_cast_leave_null_alone()


### PR DESCRIPTION
This PR fixes #185, a **lonnng** outstanding issue.

Essentially the problem is that SQL "bigint" columns can store unsigned integers up to 64-bit precision, which is technically larger than PHP_INT_MAX even on a 64-bit machine due to the 2's complement signing style that PHP uses for integers internally. The problem is even more obvious when using a 32-bit machine...

This PR fixes the problem by checking if the value would cause an overflow and instead will keep the value as a numeric string (great for SQL storage). Yes, this really only fixes an edge case, which is why it may not have been fixed earlier.

(Related: https://dev.mysql.com/doc/refman/5.5/en/integer-types.html)
