### PR TITLE
use $primary_key to fetch the primary key

### DIFF
--- a/lib/Relationship.php
+++ b/lib/Relationship.php
@@ -540,7 +540,7 @@ class HasMany extends AbstractRelationship
 		$primary_key = Inflector::instance()->variablize($this->foreign_key[0]);
 
 		return array(
-			$primary_key => $model->id,
+			$primary_key => $model->{$primary_key},
 		);
 	}
 


### PR DESCRIPTION
When having tables which do not use `id` as primary key this previously caused issues.

Guess I have to add some tests for this faulty behavior though..
