### PR TITLE
test for finding by null

### DIFF
--- a/lib/Model.php
+++ b/lib/Model.php
@@ -1645,6 +1645,11 @@ class Model
 	 */
 	public static function find_by_pk($values, $options)
 	{
+		if($values===null)
+		{
+			throw new RecordNotFound("Couldn't find ".get_called_class()." without an ID");
+		}
+
 		$table = static::table();
 
 		if($table->cache_individual_model)
@@ -1662,16 +1667,14 @@ class Model
 		if ($results != ($expected = count($values)))
 		{
 			$class = get_called_class();
+			if (is_array($values))
+				$values = join(',',$values);
 
 			if ($expected == 1)
 			{
-				if (!is_array($values))
-					$values = array($values);
-
-				throw new RecordNotFound("Couldn't find $class with ID=" . join(',',$values));
+				throw new RecordNotFound("Couldn't find $class with ID=$values");
 			}
 
-			$values = join(',',$values);
 			throw new RecordNotFound("Couldn't find all $class with IDs ($values) (found $results, but was looking for $expected)");
 		}
 		return $expected == 1 ? $list[0] : $list;

--- a/test/ActiveRecordFindTest.php
+++ b/test/ActiveRecordFindTest.php
@@ -445,6 +445,14 @@ class ActiveRecordFindTest extends DatabaseTest
 		Author::find(0);
 	}
 
+	/**
+	 * @expectedException ActiveRecord\RecordNotFound
+	 */
+	public function test_find_by_null()
+	{
+		Author::find(null);
+	}
+
 	public function test_count_by()
 	{
 		$this->assert_equals(2,Venue::count_by_state('VA'));


### PR DESCRIPTION
Fix for the following issue:

``` PHP
$author = Author::find(0);
// throws RecordNotFound exception (because count(0) == 1)

$author = Author::find(null);
// does not throw an exception (because count(null) == 0)
```
