### PR TITLE
Fix notice-level error when cache not configured

### DIFF
--- a/lib/Cache.php
+++ b/lib/Cache.php
@@ -69,15 +69,15 @@ class Cache
 	 */
 	public static function get($key, $closure, $expire=null)
 	{
+		if (!static::$adapter)
+			return $closure();
+
 		if (is_null($expire))
 		{
 			$expire = static::$options['expire'];
 		}
 
 		$key = static::get_namespace() . $key;
-
-		if (!static::$adapter)
-			return $closure();
 
 		if (!($value = static::$adapter->read($key)))
 			static::$adapter->write($key, ($value = $closure()), $expire);


### PR DESCRIPTION
When no cache is configured, code generates a notice in <code>Cache::get()</code> because <code>static::$options['expire']</code> is not set. Check for null <code>static::$adapter</code> should happen before anything else in <code>Cache::get()</code>.
