### PR TITLE
Avoid 'Undefined offset' error in is_hash(). If empty array, return false.

### DIFF
--- a/lib/Utils.php
+++ b/lib/Utils.php
@@ -63,13 +63,15 @@ function array_flatten(array $array)
 /**
  * Somewhat naive way to determine if an array is a hash.
  */
-function is_hash(&$array)
+function is_hash($array)
 {
-	if (!is_array($array) || empty($array))
+	if (!is_array($array)) {
 		return false;
+	}
 
 	$keys = array_keys($array);
-	return @is_string($keys[0]) ? true : false;
+
+	return isset($keys[0]) && is_string($keys[0]);
 }
 
 /**

--- a/lib/Utils.php
+++ b/lib/Utils.php
@@ -65,7 +65,7 @@ function array_flatten(array $array)
  */
 function is_hash(&$array)
 {
-	if (!is_array($array))
+	if (!is_array($array) || empty($array))
 		return false;
 
 	$keys = array_keys($array);

--- a/test/UtilsTest.php
+++ b/test/UtilsTest.php
@@ -103,5 +103,20 @@ class UtilsTest extends SnakeCase_PHPUnit_Framework_TestCase
 		$x = '1';
 		$this->assert_equals(array(array('1')),ActiveRecord\wrap_strings_in_arrays($x));
 	}
+	
+	public function test_is_hash()
+	{
+		$hash = array('key' => 'value');
+		$this->assert_true(ActiveRecord\is_hash($hash));
+		
+		$notHash = array(0 => 'value');
+		$this->assert_false(ActiveRecord\is_hash($notHash));
+	}
+	
+	public function test_is_hash_empty_array()
+	{
+		$notHash = array();
+		$this->assert_false(ActiveRecord\is_hash($notHash));
+	}
 };
 ?>


### PR DESCRIPTION
...e.