### PR TITLE
fix for CURRENT_TIMESTAMP

### DIFF
--- a/lib/Connection.php
+++ b/lib/Connection.php
@@ -262,7 +262,7 @@ abstract class Connection
 	{
 		$columns = array();
 		$self = $this;
-		$rows = Cache::get("get_meta_data-$table-rows", function() use ($table, $self) {
+		$rows = Cache::get("get_meta_data-".$this->protocol."-$table-rows", function() use ($table, $self) {
 			$sth = $self->query_column_info($table);
 			return $sth->fetchAll();
 		});

--- a/lib/Connection.php
+++ b/lib/Connection.php
@@ -261,9 +261,13 @@ abstract class Connection
 	public function columns($table)
 	{
 		$columns = array();
-		$sth = $this->query_column_info($table);
+		$self = $this;
+		$rows = Cache::get("get_meta_data-$table-rows", function() use ($table, $self) {
+			$sth = $self->query_column_info($table);
+			return $sth->fetchAll();
+		});
 
-		while (($row = $sth->fetch())) {
+		foreach($rows as $row){
 			$c = $this->create_column($row);
 			$columns[$c->name] = $c;
 		}

--- a/lib/Table.php
+++ b/lib/Table.php
@@ -399,7 +399,7 @@ class Table
 
 		$table_name = $this->get_fully_qualified_table_name($quote_name);
 		$conn = $this->conn;
-		$this->columns = Cache::get("get_meta_data-$table_name", function() use ($conn, $table_name) { return $conn->columns($table_name); });
+		$this->columns = $conn->columns($table_name);
 	}
 
 	/**

--- a/lib/adapters/MysqlAdapter.php
+++ b/lib/adapters/MysqlAdapter.php
@@ -65,7 +65,21 @@ class MysqlAdapter extends Connection
 		}
 
 		$c->map_raw_type();
-		$c->default = $c->cast($column['default'],$this);
+		if($column['default']=="CURRENT_TIMESTAMP")
+		{
+			static $current_time = null;
+			if(is_null($current_time))
+			{
+				$current_time = isset($_SERVER) && isset($_SERVER['REQUEST_TIME'])?$_SERVER['REQUEST_TIME']:time();
+			}
+			$date = new DateTime();
+			$date->setTimestamp($current_time);
+			$c->default = $date;
+		}
+		else
+		{
+			$c->default = $c->cast($column['default'], $this);
+		}
 
 		return $c;
 	}

--- a/lib/adapters/MysqlAdapter.php
+++ b/lib/adapters/MysqlAdapter.php
@@ -66,7 +66,7 @@ class MysqlAdapter extends Connection
 
 		$c->map_raw_type();
 		switch($column['default']){
-			case "CURRENT_TIMESTAMP":
+			case 'CURRENT_TIMESTAMP':
 				static $current_time = null;
 				if(is_null($current_time))
 				{

--- a/lib/adapters/MysqlAdapter.php
+++ b/lib/adapters/MysqlAdapter.php
@@ -65,20 +65,20 @@ class MysqlAdapter extends Connection
 		}
 
 		$c->map_raw_type();
-		if($column['default']=="CURRENT_TIMESTAMP")
-		{
-			static $current_time = null;
-			if(is_null($current_time))
-			{
-				$current_time = isset($_SERVER) && isset($_SERVER['REQUEST_TIME'])?$_SERVER['REQUEST_TIME']:time();
-			}
-			$date = new DateTime();
-			$date->setTimestamp($current_time);
-			$c->default = $date;
-		}
-		else
-		{
-			$c->default = $c->cast($column['default'], $this);
+		switch($column['default']){
+			case "CURRENT_TIMESTAMP":
+				static $current_time = null;
+				if(is_null($current_time))
+				{
+					$current_time = isset($_SERVER) && isset($_SERVER['REQUEST_TIME'])?$_SERVER['REQUEST_TIME']:time();
+				}
+				$date = new DateTime();
+				$date->setTimestamp($current_time);
+				$c->default = $date;
+				break;
+
+			default:
+				$c->default = $c->cast($column['default'], $this);
 		}
 
 		return $c;

--- a/test/ActiveRecordCacheTest.php
+++ b/test/ActiveRecordCacheTest.php
@@ -37,7 +37,7 @@ class ActiveRecordCacheTest extends DatabaseTest
 		Author::first();
 
 		$table_name = Author::table()->get_fully_qualified_table_name(!($this->conn instanceof ActiveRecord\PgsqlAdapter));
-		$value = Cache::$adapter->read("get_meta_data-$table_name");
+		$value = Cache::$adapter->read("get_meta_data-$table_name-rows");
 		$this->assert_true(is_array($value));
 	}
 }

--- a/test/ActiveRecordCacheTest.php
+++ b/test/ActiveRecordCacheTest.php
@@ -37,7 +37,7 @@ class ActiveRecordCacheTest extends DatabaseTest
 		Author::first();
 
 		$table_name = Author::table()->get_fully_qualified_table_name(!($this->conn instanceof ActiveRecord\PgsqlAdapter));
-		$value = Cache::$adapter->read("get_meta_data-$table_name-rows");
+		$value = Cache::$adapter->read("get_meta_data-".$this->conn->protocol."-$table_name-rows");
 		$this->assert_true(is_array($value));
 	}
 }

--- a/test/MysqlAdapterTest.php
+++ b/test/MysqlAdapterTest.php
@@ -36,8 +36,8 @@ class MysqlAdapterTest extends AdapterTest
 
 	public function test_construction_of_current_timestamp()
 	{
-		$event = new Event();
-		$this->assertNotEmpty($event->start_date);
+		$publisher = new Publisher();
+		$this->assertNotEmpty($publisher->start_date);
 	}
 }
 ?>

--- a/test/MysqlAdapterTest.php
+++ b/test/MysqlAdapterTest.php
@@ -33,5 +33,11 @@ class MysqlAdapterTest extends AdapterTest
 
 		$this->assert_true(strpos($this->conn->last_query, 'LIMIT 1') !== false);
 	}
+
+	public function test_construction_of_current_timestamp()
+	{
+		$event = new Event();
+		$this->assertNotEmpty($event->start_date);
+	}
 }
 ?>

--- a/test/sql/mysql.sql
+++ b/test/sql/mysql.sql
@@ -23,7 +23,8 @@ CREATE TABLE books(
 
 CREATE TABLE publishers(
 	publisher_id INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
-	name VARCHAR(25) NOT NULL DEFAULT 'default_name'
+	name VARCHAR(25) NOT NULL DEFAULT 'default_name',
+	start_date timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
 ) ENGINE=InnoDB;
 
 CREATE TABLE venues (
@@ -42,8 +43,7 @@ CREATE TABLE events (
 	host_id int NOT NULL,
 	title varchar(60) NOT NULL,
 	description varchar(50),
-	type varchar(15) default NULL,
-	start_date timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
+	type varchar(15) default NULL
 );
 
 CREATE TABLE hosts(

--- a/test/sql/mysql.sql
+++ b/test/sql/mysql.sql
@@ -42,7 +42,8 @@ CREATE TABLE events (
 	host_id int NOT NULL,
 	title varchar(60) NOT NULL,
 	description varchar(50),
-	type varchar(15) default NULL
+	type varchar(15) default NULL,
+	start_date timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
 CREATE TABLE hosts(


### PR DESCRIPTION
Cache raw table metadata, not column objects. This allows the MYSQL adapter to interpret "CURRENT_TIMESTAMP" appropriately on every request.