### PR TITLE
test case for default current_timestamp

### DIFF
--- a/test/MysqlAdapterTest.php
+++ b/test/MysqlAdapterTest.php
@@ -33,5 +33,11 @@ class MysqlAdapterTest extends AdapterTest
 
 		$this->assert_true(strpos($this->conn->last_query, 'LIMIT 1') !== false);
 	}
+
+	public function test_construction_of_current_timestamp()
+	{
+		$event = new Event();
+		$this->assertNotEmpty($event->start_date);
+	}
 }
 ?>

--- a/test/sql/mysql.sql
+++ b/test/sql/mysql.sql
@@ -42,7 +42,8 @@ CREATE TABLE events (
 	host_id int NOT NULL,
 	title varchar(60) NOT NULL,
 	description varchar(50),
-	type varchar(15) default NULL
+	type varchar(15) default NULL,
+	start_date timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
 CREATE TABLE hosts(


### PR DESCRIPTION
@koenpunt 
@EVILoptimist

This illustrates the following MYSQL Adapter bug:
1. Create a model with a column of type "timestamp" (or datetime), and default of "CURRENT_TIMESTAMP"
2. Instantiate a new model, and try to access the column

Expected result: 
You get back a DateTime, set to the current time

Actual result:
You get back null
