### PR TITLE
store cache on first fetch, expire on update

### DIFF
--- a/lib/Model.php
+++ b/lib/Model.php
@@ -848,7 +848,6 @@ class Model
 
 		$this->__new_record = false;
 		$this->invoke_callback('after_create',false);
-
 		$this->expire_cache();
 		return true;
 	}
@@ -1276,9 +1275,9 @@ class Model
 		$this->__relationships = array();
 		$pk = array_values($this->get_values_for($this->get_primary_key()));
 
+		$this->expire_cache();
 		$this->set_attributes_via_mass_assignment($this->find($pk)->attributes, false);
 		$this->reset_dirty();
-		$this->expire_cache();
 
 		return $this;
 	}
@@ -1607,7 +1606,7 @@ class Model
 	/**
 	 * Will look up a list of primary keys from cache
 	 *
-	 * @param array $pks An array of primary keys
+	 * @param mixed $pks primary keys
 	 * @return array
 	 */
 	protected static function get_models_from_cache($pks)

--- a/lib/Model.php
+++ b/lib/Model.php
@@ -154,14 +154,16 @@ class Model
 	static $sequence;
 
 	/**
-	 * Set this to true in your subclass to use caching for this model. Note that you must also configure a cache object.
+	 * Set this to true in your subclass to use caching for this model.
+	 * Note that you must also configure a cache object.
 	 */
 	static $cache = false;
 
 	/**
-	 * Set this to specify an expiration period for this model. If not set, the expire value you set in your cache options will be used.
+	 * Set this to specify an expiration period for this model.
+	 * If not set, the expire value you set in your cache options will be used.
 	 *
-	 * @var number
+	 * @var integer
 	 */
 	static $cache_expire;
 
@@ -847,7 +849,7 @@ class Model
 		$this->__new_record = false;
 		$this->invoke_callback('after_create',false);
 
-		$this->update_cache();
+		$this->expire_cache();
 		return true;
 	}
 
@@ -878,17 +880,18 @@ class Model
 			$dirty = $this->dirty_attributes();
 			static::table()->update($dirty,$pk);
 			$this->invoke_callback('after_update',false);
-			$this->update_cache();
+			$this->expire_cache();
 		}
 
 		return true;
 	}
 
-	protected function update_cache()
+	protected function expire_cache()
 	{
 		$table = static::table();
-		if($table->cache_individual_model){
-			Cache::set($this->cache_key(), $this, $table->cache_model_expire);
+		if($table->cache_individual_model)
+		{
+			Cache::delete($this->cache_key());
 		}
 	}
 
@@ -1032,18 +1035,9 @@ class Model
 
 		static::table()->delete($pk);
 		$this->invoke_callback('after_destroy',false);
-		$this->remove_from_cache();
+		$this->expire_cache();
 
 		return true;
-	}
-
-	public function remove_from_cache()
-	{
-		$table = static::table();
-		if($table->cache_individual_model)
-		{
-			Cache::delete($this->cache_key());
-		}
 	}
 
 	/**
@@ -1279,13 +1273,12 @@ class Model
 	 */
 	public function reload()
 	{
-		$this->remove_from_cache();
-
 		$this->__relationships = array();
 		$pk = array_values($this->get_values_for($this->get_primary_key()));
 
 		$this->set_attributes_via_mass_assignment($this->find($pk)->attributes, false);
 		$this->reset_dirty();
+		$this->expire_cache();
 
 		return $this;
 	}
@@ -1617,14 +1610,19 @@ class Model
 	 * @param array $pks An array of primary keys
 	 * @return array
 	 */
-	protected static function get_models_from_cache(array $pks)
+	protected static function get_models_from_cache($pks)
 	{
 		$models = array();
 		$table = static::table();
 
+		if(!is_array($pks))
+		{
+			$pks = array($pks);
+		}
+
 		foreach($pks as $pk)
 		{
-			$options =array('conditions' => static::pk_conditions($pk));
+			$options = array('conditions' => static::pk_conditions($pk));
 			$models[] = Cache::get($table->cache_key_for_model($pk), function() use ($table, $options)
 			{
 				$res = $table->find($options);
@@ -1649,8 +1647,7 @@ class Model
 
 		if($table->cache_individual_model)
 		{
-			$pks = is_array($values) ? $values : array($values);
-			$list = static::get_models_from_cache($pks);
+			$list = static::get_models_from_cache($values);
 		}
 		else
 		{

--- a/test/CacheModelTest.php
+++ b/test/CacheModelTest.php
@@ -51,15 +51,15 @@ class CacheModelTest extends DatabaseTest
 		$publisher = Publisher::find(1);
 		$method = $this->set_method_public('Publisher', 'cache_key');
 		$cache_key = $method->invokeArgs($publisher, array());
-		$publisherDirectlyFromCache = Cache::$adapter->read($cache_key);
+		$from_cache = Cache::$adapter->read($cache_key);
 
-		$this->assertEquals($publisher->name, $publisherDirectlyFromCache->name);
+		$this->assertEquals($publisher->name, $from_cache->name);
 	}
 
 	public function test_model_cache_new()
 	{
 		$publisher = new Publisher(array(
-			"name" => "HarperCollins"
+			'name' => 'HarperCollins'
 		));
 		$publisher->save();
 
@@ -81,9 +81,9 @@ class CacheModelTest extends DatabaseTest
 		foreach($publishers as $publisher)
 		{
 			$cache_key = $method->invokeArgs($publisher, array());
-			$publisherDirectlyFromCache = Cache::$adapter->read($cache_key);
+			$from_cache = Cache::$adapter->read($cache_key);
 
-			$this->assertEquals($publisher->name, $publisherDirectlyFromCache->name);
+			$this->assertEquals($publisher->name, $from_cache->name);
 		}
 	}
 
@@ -113,18 +113,38 @@ class CacheModelTest extends DatabaseTest
 
 		$publisher = Publisher::find(1);
 		$cache_key = $method->invokeArgs($publisher, array());
-		$this->assertEquals("Random House", $publisher->name);
+		$this->assertEquals('Random House', $publisher->name);
 
-		$publisherDirectlyFromCache = Cache::$adapter->read($cache_key);
-		$this->assertEquals("Random House", $publisherDirectlyFromCache->name);
+		$from_cache = Cache::$adapter->read($cache_key);
+		$this->assertEquals('Random House', $from_cache->name);
 
 		// make sure that updates make it to cache
-		$publisher->name = "Puppy Publishing";
+		$publisher->name = 'Puppy Publishing';
 		$publisher->save();
 
 		$actual = Publisher::find($publisher->id);
 		$from_cache = Cache::$adapter->read($cache_key);
 
-		$this->assertEquals("Puppy Publishing", $from_cache->name);
+		$this->assertEquals('Puppy Publishing', $from_cache->name);
 	}
+
+	public function test_model_reload_expires_cache(){
+		$method = $this->set_method_public('Publisher', 'cache_key');
+
+		$publisher = Publisher::find(1);
+		$cache_key = $method->invokeArgs($publisher, array());
+		$this->assertEquals('Random House', $publisher->name);
+
+		// Raw query to not update model properties
+		Publisher::query('UPDATE publishers SET name = ? WHERE publisher_id = ?', array('Specific House', 1));
+
+		$publisher->reload();
+
+		$this->assertEquals('Specific House', $publisher->name);
+
+		$from_cache = Cache::$adapter->read($cache_key);
+
+		$this->assertEquals('Specific House', $from_cache->name);
+	}
+
 }

--- a/test/CacheModelTest.php
+++ b/test/CacheModelTest.php
@@ -59,17 +59,18 @@ class CacheModelTest extends DatabaseTest
 	public function test_model_cache_new()
 	{
 		$publisher = new Publisher(array(
-		   "name"=>"HarperCollins"
+			"name" => "HarperCollins"
 		));
 		$publisher->save();
 
 		$method = $this->set_method_public('Publisher', 'cache_key');
 		$cache_key = $method->invokeArgs($publisher, array());
 
-		$publisherDirectlyFromCache = Cache::$adapter->read($cache_key);
+		// Model is cached on first find
+		$actual = Publisher::find($publisher->id);
+		$from_cache = Cache::$adapter->read($cache_key);
 
-		$this->assertTrue(is_object($publisherDirectlyFromCache));
-		$this->assertEquals($publisher->name, $publisherDirectlyFromCache->name);
+		$this->assertEquals($actual, $from_cache);
 	}
 
 	public function test_model_cache_find()
@@ -121,7 +122,9 @@ class CacheModelTest extends DatabaseTest
 		$publisher->name = "Puppy Publishing";
 		$publisher->save();
 
-		$publisherDirectlyFromCache = Cache::$adapter->read($cache_key);
-		$this->assertEquals("Puppy Publishing", $publisherDirectlyFromCache->name);
+		$actual = Publisher::find($publisher->id);
+		$from_cache = Cache::$adapter->read($cache_key);
+
+		$this->assertEquals("Puppy Publishing", $from_cache->name);
 	}
 }


### PR DESCRIPTION
Store a cached version of the model on first fetch, instead of create/update. Expire cache on create, update or delete. 
This prevents caching of `null` values for columns with (dynamic) defaults in the database.

**Todo:**
- [x] Add test for using reload on cached model
