### PR TITLE
remove broken method

### DIFF
--- a/test/SqliteAdapterTest.php
+++ b/test/SqliteAdapterTest.php
@@ -15,14 +15,6 @@ class SqliteAdapterTest extends AdapterTest
 		@unlink(self::InvalidDb);
 	}
 
-
-	public static function _tearDownAfterClass()
-	{
-		parent::tearDownAfterClass();
-
-		@unlink($this->db);
-	}
-
 	public function testConnectToInvalidDatabaseShouldNotCreateDbFile()
 	{
 		try


### PR DESCRIPTION
The _tearDownAfterClass method is not only broken (accessing $this in a static context), but also unused.
