### PR TITLE
store reference to sqlite db in static to be accessible in tearDownAfterClass

### DIFF
--- a/test/SqliteAdapterTest.php
+++ b/test/SqliteAdapterTest.php
@@ -16,11 +16,11 @@ class SqliteAdapterTest extends AdapterTest
 	}
 
 
-	public static function _tearDownAfterClass()
+	public static function tearDownAfterClass()
 	{
 		parent::tearDownAfterClass();
 
-		@unlink($this->db);
+		@unlink(static::$db);
 	}
 
 	public function testConnectToInvalidDatabaseShouldNotCreateDbFile()

--- a/test/helpers/DatabaseTest.php
+++ b/test/helpers/DatabaseTest.php
@@ -5,6 +5,7 @@ class DatabaseTest extends SnakeCase_PHPUnit_Framework_TestCase
 {
 	protected $conn;
 	public static $log = false;
+	public static $db;
 
 	public function set_up($connection_name=null)
 	{
@@ -19,8 +20,8 @@ class DatabaseTest extends SnakeCase_PHPUnit_Framework_TestCase
 		if ($connection_name == 'sqlite' || $config->get_default_connection() == 'sqlite')
 		{
 			// need to create the db. the adapter specifically does not create it for us.
-			$this->db = substr(ActiveRecord\Config::instance()->get_connection('sqlite'),9);
-			new SQLite3($this->db);
+			static::$db = substr(ActiveRecord\Config::instance()->get_connection('sqlite'),9);
+			new SQLite3(static::$db);
 		}
 
 		$this->connection_name = $connection_name;


### PR DESCRIPTION
fixes #462
