### PR TITLE
remove travis skip fix

### DIFF
--- a/test/ActiveRecordFindTest.php
+++ b/test/ActiveRecordFindTest.php
@@ -468,11 +468,6 @@ class ActiveRecordFindTest extends DatabaseTest
 
 	public function test_find_by_datetime()
 	{
-		if ( getenv('TRAVIS') ) $this->markTestSkipped(
-			'The Travis CI environment seems to screw this up for unknonwn reasons; ' .
-			'see Github #298 (https://github.com/kla/php-activerecord/issues/298)'
-		);
-
 		$now = new DateTime();
 		$arnow = new ActiveRecord\DateTime();
 		$arnow->setTimestamp($now->getTimestamp());


### PR DESCRIPTION
recently discovered that date and time is no longer an issue on travis.