### PR TITLE
Feature: StrongParameters

### DIFF
--- a/ActiveRecord.php
+++ b/ActiveRecord.php
@@ -24,6 +24,7 @@ require __DIR__.'/lib/Inflector.php';
 require __DIR__.'/lib/CallBack.php';
 require __DIR__.'/lib/Exceptions.php';
 require __DIR__.'/lib/Cache.php';
+require __DIR__.'/lib/StrongParameters.php';
 
 if (!defined('PHP_ACTIVERECORD_AUTOLOAD_DISABLE'))
 	spl_autoload_register('activerecord_autoload',false,PHP_ACTIVERECORD_AUTOLOAD_PREPEND);

--- a/lib/Config.php
+++ b/lib/Config.php
@@ -88,6 +88,13 @@ class Config extends Singleton
 	private $date_format = \DateTime::ISO8601;
 
 	/**
+	 * Switch for use of StrongParameters
+	 *
+	 * @var bool
+	 */
+	private $require_strong_parameters = false;
+
+	/**
 	 * Allows config initialization using a closure.
 	 *
 	 * This method is just syntatic sugar.
@@ -357,4 +364,26 @@ class Config extends Singleton
 	{
 		Cache::initialize($url,$options);
 	}
+
+	/**
+	 * Enable or disable use of StrongParameters
+	 *
+	 * @param bool $flag
+	 * @return void
+	 */
+	public function set_require_strong_parameters($flag)
+	{
+		$this->require_strong_parameters = $flag;
+	}
+
+	/**
+	 * Returns whether or not to require StrongParameters
+	 *
+	 * @return bool
+	 */
+	public function get_require_strong_parameters()
+	{
+		return $this->require_strong_parameters;
+	}
+
 }

--- a/lib/Exceptions.php
+++ b/lib/Exceptions.php
@@ -148,3 +148,10 @@ class HasManyThroughAssociationException extends RelationshipException {}
  * @package ActiveRecord
  */
 class UnsafeParametersException extends ActiveRecordException {}
+
+/**
+ * Thrown for non existing parameter from requireParam
+ *
+ * @package ActiveRecord
+ */
+class ParameterMissingException extends ActiveRecordException {}

--- a/lib/Exceptions.php
+++ b/lib/Exceptions.php
@@ -141,3 +141,10 @@ class RelationshipException extends ActiveRecordException {}
  * @package ActiveRecord
  */
 class HasManyThroughAssociationException extends RelationshipException {}
+
+/**
+ * Thrown for unsafe in attributes in mass assignment
+ *
+ * @package ActiveRecord
+ */
+class UnsafeParametersException extends ActiveRecordException {}

--- a/lib/Model.php
+++ b/lib/Model.php
@@ -272,13 +272,14 @@ class Model
 	 * new Person(array('first_name' => 'Tito', 'last_name' => 'the Grief'));
 	 * </code>
 	 *
-	 * @param array $attributes Hash containing names and values to mass assign to the model
+	 * @param array $attributes Hash containing names and values to mass assign to the model or
+	 *  StrongParameters object
 	 * @param boolean $guard_attributes Set to true to guard protected/non-accessible attributes
 	 * @param boolean $instantiating_via_find Set to true if this model is being created from a find call
 	 * @param boolean $new_record Set to true if this should be considered a new record
 	 * @return Model
 	 */
-	public function __construct(array $attributes=array(), $guard_attributes=true, $instantiating_via_find=false, $new_record=true)
+	public function __construct($attributes=null, $guard_attributes=true, $instantiating_via_find=false, $new_record=true)
 	{
 		$this->__new_record = $new_record;
 
@@ -1225,9 +1226,10 @@ class Model
 	}
 
 	/**
-	 * Mass update the model with an array of attribute data and saves to the database.
+	 * Mass update the model with attribute data and saves to the database.
 	 *
-	 * @param array $attributes An attribute data array in the form array(name => value, ...)
+	 * @param StrongParameters|array $attributes An StrongParameters object or array
+	 *  containing data to update in the form array(name => value, ...)
 	 * @return boolean True if successfully updated and saved otherwise false
 	 */
 	public function update_attributes($attributes)
@@ -1250,15 +1252,16 @@ class Model
 	}
 
 	/**
-	 * Mass update the model with data from an attributes hash.
+	 * Mass update the model with data from an attributes hash or object.
 	 *
 	 * Unlike update_attributes() this method only updates the model's data
 	 * but DOES NOT save it to the database.
 	 *
 	 * @see update_attributes
-	 * @param array $attributes An array containing data to update in the form array(name => value, ...)
+	 * @param StrongParameters|array $attributes An StrongParameters object or array
+	 *  containing data to update in the form array(name => value, ...)
 	 */
-	public function set_attributes(array $attributes)
+	public function set_attributes($attributes)
 	{
 		$this->set_attributes_via_mass_assignment($attributes, true);
 	}
@@ -1267,35 +1270,48 @@ class Model
 	 * Passing $guard_attributes as true will throw an exception if an attribute does not exist.
 	 *
 	 * @throws \ActiveRecord\UndefinedPropertyException
-	 * @param array $attributes An array in the form array(name => value, ...)
+	 * @param StrongParameters|array $attributes An StrongParameters object or array
+	 *  containing data to update in the form array(name => value, ...)
 	 * @param boolean $guard_attributes Flag of whether or not protected/non-accessible attributes should be guarded
 	 */
-	private function set_attributes_via_mass_assignment(array &$attributes, $guard_attributes)
+	private function set_attributes_via_mass_assignment(&$attributes, $guard_attributes)
 	{
-		//access uninflected columns since that is what we would have in result set
+		// return fast when no attributes are given
+		if(empty($attributes)) return;
+
+		$require_strong_parameters = Config::instance()->get_require_strong_parameters();
+		if($guard_attributes && $require_strong_parameters && !($attributes instanceof StrongParameters))
+		{
+			throw new UnsafeParametersException();
+		}
+
+		// Legacy support for attr_accessible/attr_protected
+		// Recommended way of protecting attributes is by using StrongParameters
+		if($guard_attributes && !($attributes instanceof StrongParameters))
+		{
+			if (!empty(static::$attr_accessible))
+				$attributes = array_intersect_key($attributes, array_flip(static::$attr_accessible));
+
+			if (!empty(static::$attr_protected))
+				$attributes = array_diff_key($attributes, array_flip(static::$attr_protected));
+		}
+
 		$table = static::table();
 		$exceptions = array();
-		$use_attr_accessible = !empty(static::$attr_accessible);
-		$use_attr_protected = !empty(static::$attr_protected);
 		$connection = static::connection();
 
+		// access uninflected columns since that is what we would have in result set
 		foreach ($attributes as $name => $value)
 		{
 			// is a normal field on the table
-			if (array_key_exists($name,$table->columns))
+			if (array_key_exists($name, $table->columns))
 			{
-				$value = $table->columns[$name]->cast($value,$connection);
+				$value = $table->columns[$name]->cast($value, $connection);
 				$name = $table->columns[$name]->inflected_name;
 			}
 
 			if ($guard_attributes)
 			{
-				if ($use_attr_accessible && !in_array($name,static::$attr_accessible))
-					continue;
-
-				if ($use_attr_protected && in_array($name,static::$attr_protected))
-					continue;
-
 				// set valid table data
 				try {
 					$this->$name = $value;
@@ -1310,7 +1326,7 @@ class Model
 					continue;
 
 				// set arbitrary data
-				$this->assign_attribute($name,$value);
+				$this->assign_attribute($name, $value);
 			}
 		}
 

--- a/lib/StrongParameters.php
+++ b/lib/StrongParameters.php
@@ -80,7 +80,7 @@ class StrongParameters implements IteratorAggregate
 	{
 		return array_map(function($value)
 		{
-			if (!is_array($value))
+			if (!is_hash($value))
 			{
 				return $value;
 			}

--- a/lib/StrongParameters.php
+++ b/lib/StrongParameters.php
@@ -14,7 +14,7 @@ use ArrayIterator;
  *
  *   public function beforeFilter()
  *   {
- *       $this->request->params = new ActiveRecord\StrongParameters($_POST);
+ *       $this->params = new ActiveRecord\StrongParameters($_POST);
  *   }
  *
  * This assumes that your POST data is grouped as follows;
@@ -38,7 +38,7 @@ use ArrayIterator;
  *
  *   protected function user_params()
  *   {
- *       return $this->request->params->requireParam('user')->permit('name', 'bio', 'email');
+ *       return $this->params->require_param('user')->permit('name', 'bio', 'email');
  *   }
  *
  *
@@ -137,6 +137,14 @@ class StrongParameters implements IteratorAggregate
 			throw new ParameterMissingException("Missing param '$key'");
 		}
 		return $param;
+	}
+
+	/**
+	 * @see requireParam
+	 */
+	public function require_param($key)
+	{
+		return $this->requireParam($key);
 	}
 
 	/**

--- a/lib/StrongParameters.php
+++ b/lib/StrongParameters.php
@@ -108,6 +108,12 @@ class StrongParameters implements IteratorAggregate
 		return $this;
 	}
 
+	/**
+	 * Fetch a value from the data
+	 *
+	 * @param string $key
+	 * @return mixed
+	 */
 	public function fetch($key)
 	{
 		if (isset($this->data[$key])) {
@@ -116,6 +122,14 @@ class StrongParameters implements IteratorAggregate
 		return null;
 	}
 
+	/**
+	 * Fetch a required value from the data. If the param doesn't exist an error
+	 * is thrown
+	 *
+	 * @param string $key
+	 * @throws ActiveRecord\ParameterMissingException
+	 * @return mixed
+	 */
 	public function requireParam($key)
 	{
 		$param = $this->fetch($key);

--- a/lib/StrongParameters.php
+++ b/lib/StrongParameters.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace ActiveRecord;
+
+use IteratorAggregate;
+use ArrayIterator;
+
+/**
+ * The use of StrongParameters is implementation dependent.
+ *
+ * You probably want to integrate this somewhere in your application where the POST data is processed.
+ *
+ * For example, in your Controller class you can process the POST data:
+ *
+ *   public function beforeFilter()
+ *   {
+ *       foreach($_POST as $group => $params)
+ *       {
+ *           $this->request->data[$group] = new ActiveRecord\StrongParameters($params);
+ *       }
+ *   }
+ *
+ * This assumes that your POST data is grouped as follows;
+ *
+ *   $_POST = array(
+ *       "user" => array(
+ *           "name" => "Foo Bar",
+ *           "bio" => "I'm Foo Bar",
+ *           "email" => "foo@bar.baz"
+ *       )
+ *   )
+ *
+ * And then in the UserController class you can access the data
+ *
+ *   public function update_profile()
+ *   {
+ *       $user = User::find($this->request->params['id']);
+ *       $user->update_attributes($this->user_params());
+ *       $this->redirect('back');
+ *   }
+ *
+ *   protected function user_params()
+ *   {
+ *       return $this->request->data['user']->permit('name', 'bio', 'email');
+ *   }
+ *
+ *
+ * @package ActiveRecord
+ */
+class StrongParameters implements IteratorAggregate
+{
+	/**
+	 * Array containing data
+	 *
+	 * @var array
+	 */
+	protected $data = array();
+
+	/**
+	 * Array containing permitted attributes
+	 *
+	 * @var array
+	 */
+	protected $permitted = array();
+
+	/**
+	 * Construct StrongParameters object with data
+	 *
+	 * @param array $data
+	 * @return void
+	 */
+	public function __construct(array $data = array())
+	{
+		$this->data = $data;
+	}
+
+	/**
+	 * Permit the specified attributes to be returned for mass assignment.
+	 *
+	 * @param mixed $attrs,...
+	 * @return void
+	 */
+	public function permit($attrs = array()/* [, ...$attr] */)
+	{
+		if(func_num_args() > 1)
+		{
+			$attrs = func_get_args();
+		}
+		elseif(!is_array($attrs))
+		{
+			$attrs = array($attrs);
+		}
+		$this->permitted = $attrs;
+	}
+
+	/**
+	 * Required method for IteratorAggregate interface.
+	 *
+	 * @return ArrayIterator iterator for permitted data.
+	 */
+	public function getIterator()
+	{
+		$permitted_data = array_intersect_key($this->data, array_flip($this->permitted));
+		return new ArrayIterator($permitted_data);
+	}
+
+}

--- a/test/StrongParametersModelTest.php
+++ b/test/StrongParametersModelTest.php
@@ -1,26 +1,30 @@
 <?php
 
-class StrongParametersModelTest extends DatabaseTest
+namespace ActiveRecord;
+
+use Book;
+
+class StrongParametersModelTest extends \DatabaseTest
 {
 
 	private static $require_strong_parameters;
 
 	public static function setUpBeforeClass()
 	{
-		$config = ActiveRecord\Config::instance();
+		$config = Config::instance();
 		self::$require_strong_parameters = $config->get_require_strong_parameters();
 		$config->set_require_strong_parameters(true);
 	}
 
 	public static function tearDownAfterClass()
 	{
-		$config = ActiveRecord\Config::instance();
+		$config = Config::instance();
 		$config->set_require_strong_parameters(self::$require_strong_parameters);
 	}
 
 	public function testConstructWithStrongParameters()
 	{
-		$params = new ActiveRecord\StrongParameters(array(
+		$params = new StrongParameters(array(
 			'name' => 'Foo',
 		));
 		$book = new Book($params);
@@ -36,7 +40,7 @@ class StrongParametersModelTest extends DatabaseTest
 	 */
 	public function testConstructWithoutStrongParametersThrowsException()
 	{
-		$config = ActiveRecord\Config::instance();
+		$config = Config::instance();
 		$require_strong_parameters = $config->get_require_strong_parameters();
 		$config->set_require_strong_parameters(true);
 
@@ -46,7 +50,7 @@ class StrongParametersModelTest extends DatabaseTest
 
 	public function testUpdateAttributesWithStrongParameters()
 	{
-		$params = new ActiveRecord\StrongParameters(array(
+		$params = new StrongParameters(array(
 			'name' => 'Foo',
 		));
 		$book = new Book();
@@ -63,7 +67,7 @@ class StrongParametersModelTest extends DatabaseTest
 	 */
 	public function testUpdateAttributesWithoutStrongParameters()
 	{
-		$config = ActiveRecord\Config::instance();
+		$config = Config::instance();
 		$require_strong_parameters = $config->get_require_strong_parameters();
 		$config->set_require_strong_parameters(true);
 

--- a/test/StrongParametersModelTest.php
+++ b/test/StrongParametersModelTest.php
@@ -1,0 +1,76 @@
+<?php
+
+class StrongParametersModelTest extends DatabaseTest
+{
+
+	private static $require_strong_parameters;
+
+	public static function setUpBeforeClass()
+	{
+		$config = ActiveRecord\Config::instance();
+		self::$require_strong_parameters = $config->get_require_strong_parameters();
+		$config->set_require_strong_parameters(true);
+	}
+
+	public static function tearDownAfterClass()
+	{
+		$config = ActiveRecord\Config::instance();
+		$config->set_require_strong_parameters(self::$require_strong_parameters);
+	}
+
+	public function testConstructWithStrongParameters()
+	{
+		$params = new ActiveRecord\StrongParameters(array(
+			'name' => 'Foo',
+		));
+		$book = new Book($params);
+		$this->assertNull($book->name);
+
+		$params->permit('name');
+		$book = new Book($params);
+		$this->assertEquals('Foo', $book->name);
+	}
+
+	/**
+	 * @expectedException ActiveRecord\UnsafeParametersException
+	 */
+	public function testConstructWithoutStrongParametersThrowsException()
+	{
+		$config = ActiveRecord\Config::instance();
+		$require_strong_parameters = $config->get_require_strong_parameters();
+		$config->set_require_strong_parameters(true);
+
+		$params = array('name' => 'Foo');
+		$book = new Book($params);
+	}
+
+	public function testUpdateAttributesWithStrongParameters()
+	{
+		$params = new ActiveRecord\StrongParameters(array(
+			'name' => 'Foo',
+		));
+		$book = new Book();
+		$book->update_attributes($params);
+		$this->assertNull($book->name);
+
+		$params->permit('name');
+		$book->update_attributes($params);
+		$this->assertEquals('Foo', $book->name);
+	}
+
+	/**
+	 * @expectedException ActiveRecord\UnsafeParametersException
+	 */
+	public function testUpdateAttributesWithoutStrongParameters()
+	{
+		$config = ActiveRecord\Config::instance();
+		$require_strong_parameters = $config->get_require_strong_parameters();
+		$config->set_require_strong_parameters(true);
+
+		$params = array('name' => 'Foo');
+		$book = new Book();
+		$book->update_attributes($params);
+	}
+
+
+}

--- a/test/StrongParametersTest.php
+++ b/test/StrongParametersTest.php
@@ -1,52 +1,96 @@
 <?php
 
-class StrongParametersTest extends SnakeCase_PHPUnit_Framework_TestCase
+namespace ActiveRecord;
+
+class StrongParametersTest extends \PHPUnit_Framework_TestCase
 {
 
 	public function setUp(){
-		$this->obj = new ActiveRecord\StrongParameters(array(
-			'name' => 'Foo Bar',
-			'email' => 'foo@bar.baz',
-			'bio' => 'I am Foo Bar',
-			'is_admin' => true
+		$this->params = new StrongParameters(array(
+			'user' => array(
+				'name' => 'Foo Bar',
+				'email' => 'foo@bar.baz',
+				'bio' => 'I am Foo Bar',
+				'is_admin' => true,
+			),
 		));
 	}
 
 	public function testConstruct()
 	{
-		$obj = new ActiveRecord\StrongParameters(array('name' => 'Foo Bar'));
-		$this->assertInstanceOf('ActiveRecord\StrongParameters', $obj);
-	}
-
-	/**
-	 * @expectedException PHPUnit_Framework_Error
-	 */
-	public function testConstructWithObjectTriggersError()
-	{
-		$obj = new ActiveRecord\StrongParameters((object)array('name' => 'Foo Bar'));
+		$params = new StrongParameters(array('name' => 'Foo Bar'));
+		$this->assertInstanceOf('ActiveRecord\StrongParameters', $params);
 	}
 
 	public function testPermit()
 	{
-		$this->obj->permit();
+		$params = new StrongParameters(array(
+			'name' => 'Foo Bar',
+			'email' => 'foo@bar.baz',
+			'bio' => 'I am Foo Bar',
+			'is_admin' => true,
+		));
+		$params->permit();
 		$expected = array();
-		$actual = iterator_to_array($this->obj);
+		$actual = iterator_to_array($params);
 		$this->assertEquals($expected, $actual);
 
-		$this->obj->permit(array('name', 'email'));
+		$params->permit(array('name', 'email'));
 		$expected = array('name' => 'Foo Bar', 'email' => 'foo@bar.baz');
-		$actual = iterator_to_array($this->obj);
+		$actual = iterator_to_array($params);
 		$this->assertEquals($expected, $actual);
 
-		$this->obj->permit('name', 'bio');
+		$params->permit('name', 'bio');
 		$expected = array('name' => 'Foo Bar', 'bio' => 'I am Foo Bar');
-		$actual = iterator_to_array($this->obj);
+		$actual = iterator_to_array($params);
 		$this->assertEquals($expected, $actual);
+	}
+
+	public function testPermitReturnsSelf()
+	{
+		$params = new StrongParameters(array(
+			'name' => 'Foo Bar',
+			'email' => 'foo@bar.baz',
+			'bio' => 'I am Foo Bar',
+			'is_admin' => true,
+		));
+
+		$expected = array('name' => 'Foo Bar');
+		$actual = iterator_to_array($params->permit('name'));
+		$this->assertEquals($expected, $actual);
+
+		$expected = array('name' => 'Foo Bar', 'bio' => 'I am Foo Bar');
+		$actual = iterator_to_array($params->permit('name', 'bio'));
+		$this->assertEquals($expected, $actual);
+	}
+
+	public function testRequireParam()
+	{
+		$this->assertInstanceOf('ActiveRecord\StrongParameters', $this->params->requireParam('user'));
+	}
+
+	/**
+	 * @expectedException ActiveRecord\ParameterMissingException
+	 */
+	public function testRequireParamThrowsOnMissingParam()
+	{
+		$this->params->requireParam('nonexisting');
+	}
+
+
+	public function testFetch()
+	{
+		$params = new StrongParameters(array('name' => 'Foo Bar'));
+		$this->assertEquals('Foo Bar', $params->fetch('name'));
+
+		$this->assertInstanceOf('ActiveRecord\StrongParameters', $this->params->fetch('user'));
+		
+		$this->assertEquals('Foo Bar', $this->params->fetch('user')->fetch('name'));
 	}
 
 	public function testGetIterator()
 	{
-		$this->assertInstanceOf('ArrayIterator', $this->obj->getIterator());
+		$this->assertInstanceOf('ArrayIterator', $this->params->getIterator());
 	}
 
 }

--- a/test/StrongParametersTest.php
+++ b/test/StrongParametersTest.php
@@ -77,7 +77,6 @@ class StrongParametersTest extends \PHPUnit_Framework_TestCase
 		$this->params->requireParam('nonexisting');
 	}
 
-
 	public function testFetch()
 	{
 		$params = new StrongParameters(array('name' => 'Foo Bar'));
@@ -91,6 +90,68 @@ class StrongParametersTest extends \PHPUnit_Framework_TestCase
 	public function testGetIterator()
 	{
 		$this->assertInstanceOf('ArrayIterator', $this->params->getIterator());
+	}
+
+	public function testArrayAccessOffsetExists()
+	{
+		$params = new StrongParameters(array('name' => 'Foo Bar'));
+		$this->assertTrue(isset($params['name']));
+		$this->assertFalse(isset($params['undefined']));
+	}
+
+	public function testArrayAccessOffsetGet()
+	{
+		$params = new StrongParameters(array('name' => 'Foo Bar'));
+		$this->assertEquals('Foo Bar', $params['name']);
+
+		$this->assertEquals('Foo Bar', $this->params['user']->fetch('name'));
+		$this->assertEquals('Foo Bar', $this->params['user']['name']);
+	}
+
+	public function testArrayAccessOffsetSet()
+	{
+		$params = new StrongParameters(array('name' => 'Foo Bar'));
+		$params['test'] = 'foobar';
+		$params->permit('test', 'name');
+		$this->assertEquals(array('name' => 'Foo Bar', 'test' => 'foobar'), iterator_to_array($params));
+	}
+
+	/**
+	 * @expectedException InvalidArgumentException
+	 * @expectedExceptionMessage offset cannot be null
+	 */
+	public function testArrayAccessOffsetSetThrowsOnNull()
+	{
+		$params = new StrongParameters(array('name' => 'Foo Bar'));
+		$params[] = 'foobar';
+	}
+
+	public function testArrayAccessOffsetUnset()
+	{
+		$params = new StrongParameters(array('name' => 'Foo Bar'));
+		$params['test'] = 'foobar';
+		$params->permit('test', 'name');
+		$this->assertEquals(array('name' => 'Foo Bar', 'test' => 'foobar'), iterator_to_array($params));
+		unset($params['test']);
+		$this->assertEquals(array('name' => 'Foo Bar'), iterator_to_array($params));
+		unset($params['name']);
+		$this->assertEquals(array(), iterator_to_array($params));
+	}
+
+	public function testArrayAccessOffsetUnsetNested()
+	{
+		$user = $this->params->fetch('user');
+		$user->permit('name', 'email');
+
+		$this->assertEquals(array(
+			'name' => 'Foo Bar',
+			'email' => 'foo@bar.baz',
+		), iterator_to_array($user));
+
+		unset($this->params['user']['name']);
+		$this->assertEquals(array(
+			'email' => 'foo@bar.baz',
+		), iterator_to_array($user));
 	}
 
 }

--- a/test/StrongParametersTest.php
+++ b/test/StrongParametersTest.php
@@ -1,0 +1,53 @@
+<?php
+
+class StrongParametersTest extends SnakeCase_PHPUnit_Framework_TestCase
+{
+
+	public function setUp(){
+		$this->obj = new ActiveRecord\StrongParameters(array(
+			'name' => 'Foo Bar',
+			'email' => 'foo@bar.baz',
+			'bio' => 'I am Foo Bar',
+			'is_admin' => true
+		));
+	}
+
+	public function testConstruct()
+	{
+		$obj = new ActiveRecord\StrongParameters(array('name' => 'Foo Bar'));
+		$this->assertInstanceOf('ActiveRecord\StrongParameters', $obj);
+	}
+
+	/**
+	 * @expectedException PHPUnit_Framework_Error
+	 */
+	public function testConstructWithObjectTriggersError()
+	{
+		$obj = new ActiveRecord\StrongParameters((object)array('name' => 'Foo Bar'));
+	}
+
+	public function testPermit()
+	{
+		$this->obj->permit();
+		$expected = array();
+		$actual = iterator_to_array($this->obj);
+		$this->assertEquals($expected, $actual);
+
+		$this->obj->permit(array('name', 'email'));
+		$expected = array('name' => 'Foo Bar', 'email' => 'foo@bar.baz');
+		$actual = iterator_to_array($this->obj);
+		$this->assertEquals($expected, $actual);
+
+		$this->obj->permit('name', 'bio');
+		$expected = array('name' => 'Foo Bar', 'bio' => 'I am Foo Bar');
+		$actual = iterator_to_array($this->obj);
+		$this->assertEquals($expected, $actual);
+	}
+
+	public function testGetIterator()
+	{
+		$this->assertInstanceOf('ArrayIterator', $this->obj->getIterator());
+	}
+
+}
+


### PR DESCRIPTION
Protect mass assignment by filtering input data using StrongParameters

``` php
Config::instance()->set_require_strong_parameters(true);

$params = new ActiveRecord\StrongParameters($_POST);
$user_params = $params->require_param('user');
$user_params->permit('name', 'bio');
$user = new User($user_params);
$user->save();
```

_(cc: #287)_


**NB** this is a pull request to the `1.1-dev` branch