### PR TITLE
Feature - Testing with strict `sql_mode`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ install: composer install --prefer-source --dev
 before_script:
   - echo 'extension = "memcache.so"' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - mysql -e 'CREATE DATABASE phpar_test;'
+  - mysql -e "SET GLOBAL sql_mode = 'NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES'"
   - psql -c 'CREATE DATABASE phpar_test;' -U postgres
 
 services:

--- a/test/sql/mysql.sql
+++ b/test/sql/mysql.sql
@@ -1,3 +1,7 @@
+# Set our `sql_mode` for strict testing
+SET SESSION sql_mode = 'NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES'
+
+
 CREATE TABLE authors(
 	author_id INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
 	parent_author_id INT,


### PR DESCRIPTION
This PR sets the MySQL `sql_mode` to a strict setting for our tests.

We do this in two ways/places:
- Set it **globally** for Travis-CI, since we want all travis tests to be strict and we don't care about messing with the environment since its temporary anyway
- Set it for the **session** when testing locally, so that it doesn't change your local MySQL configuration semi-permanently (which may be used for other local DB's)

Setting the `sql_mode` in this way should make our testing more reliable and will most likely even restore the seemingly vanished bug described in #438 (that was originally fixed in #317 and then again in #440).