### PR TITLE
Feature - Testing with strict `sql_mode`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ install: composer install --prefer-source --dev
 before_script:
   - echo 'extension = "memcache.so"' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - mysql -e 'CREATE DATABASE phpar_test;'
+  - mysql -e "SET GLOBAL sql_mode = 'NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES'"
   - psql -c 'CREATE DATABASE phpar_test;' -U postgres
 
 services:

--- a/test/sql/mysql.sql
+++ b/test/sql/mysql.sql
@@ -1,5 +1,5 @@
 # Set our `sql_mode` for strict testing
-SET SESSION sql_mode = 'NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES'
+SET SESSION sql_mode = 'NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES';
 
 
 CREATE TABLE `authors` (

--- a/test/sql/mysql.sql
+++ b/test/sql/mysql.sql
@@ -3,8 +3,8 @@ SET SESSION sql_mode = 'NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES'
 
 
 CREATE TABLE `authors` (
-  `author_id` int NOT NULL AUTO_INCREMENT,
-  `parent_author_id` int,
+  `author_id` int(11) NOT NULL AUTO_INCREMENT,
+  `parent_author_id` int(11),
   `name` varchar(25) NOT NULL DEFAULT 'default_name',
   `updated_at` datetime,
   `created_at` datetime,
@@ -18,9 +18,9 @@ CREATE TABLE `authors` (
 ) ENGINE=InnoDB;
 
 CREATE TABLE `books` (
-  `book_id` int NOT NULL AUTO_INCREMENT,
-  `author_id` int,
-  `secondary_author_id` int,
+  `book_id` int(11) NOT NULL AUTO_INCREMENT,
+  `author_id` int(11),
+  `secondary_author_id` int(11),
   `name` varchar(50),
   `numeric_test` varchar(10) DEFAULT '0',
   `special` numeric(10,2) DEFAULT 0,
@@ -28,26 +28,26 @@ CREATE TABLE `books` (
 );
 
 CREATE TABLE `publishers` (
-  `publisher_id` int NOT NULL AUTO_INCREMENT,
+  `publisher_id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(25) NOT NULL DEFAULT 'default_name',
   PRIMARY KEY (`publisher_id`)
 ) ENGINE=InnoDB;
 
 CREATE TABLE `venues` (
-  `id` int NOT NULL AUTO_INCREMENT,
+  `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(50),
   `city` varchar(60),
   `state` char(2),
   `address` varchar(50),
   `phone` varchar(10) default NULL,
   PRIMARY KEY (`id`),
-  UNIQUE(name,address)
+  UNIQUE(`name`,`address`)
 );
 
 CREATE TABLE `events` (
-  `id` int NOT NULL AUTO_INCREMENT,
-  `venue_id` int NULL,
-  `host_id` int NOT NULL,
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `venue_id` int(11) NULL,
+  `host_id` int(11) NOT NULL,
   `title` varchar(60) NOT NULL,
   `description` varchar(50),
   PRIMARY KEY (`id`),
@@ -55,13 +55,13 @@ CREATE TABLE `events` (
 );
 
 CREATE TABLE `hosts` (
-  `id` int NOT NULL AUTO_INCREMENT,
+  `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(25),
   PRIMARY KEY (`id`)
 );
 
 CREATE TABLE `employees` (
-  `id` int NOT NULL AUTO_INCREMENT,
+  `id` int(11) NOT NULL AUTO_INCREMENT,
   `first_name` varchar(255) NOT NULL,
   `last_name` varchar(255) NOT NULL,
   `nick_name` varchar(255) NOT NULL,
@@ -69,23 +69,23 @@ CREATE TABLE `employees` (
 );
 
 CREATE TABLE `positions` (
-  `id` int NOT NULL AUTO_INCREMENT,
-  `employee_id` int NOT NULL,
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `employee_id` int(11) NOT NULL,
   `title` varchar(255) NOT NULL,
-  `active` smallint NOT NULL,
+  `active` smallint(11) NOT NULL,
   PRIMARY KEY (`id`)
 );
 
 CREATE TABLE `rm-bldg`(
-  `rm-id` int NOT NULL,
+  `rm-id` int(11) NOT NULL,
   `rm-name` varchar(10) NOT NULL,
   `space out` varchar(1) NOT NULL
 );
 
 CREATE TABLE `awesome_people` (
-  `id` int NOT NULL AUTO_INCREMENT,
-  `author_id` int,
-  `is_awesome` int default 1,
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `author_id` int(11),
+  `is_awesome` int(11) default 1,
   PRIMARY KEY (`id`)
 );
 
@@ -108,24 +108,24 @@ CREATE TABLE `property_amenities` (
 );
 
 CREATE TABLE `users` (
-  `id` int NOT NULL AUTO_INCREMENT,
+  `id` int(11) NOT NULL AUTO_INCREMENT,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB;
 
 CREATE TABLE `newsletters` (
-  `id` int NOT NULL AUTO_INCREMENT,
+  `id` int(11) NOT NULL AUTO_INCREMENT,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB;
 
 CREATE TABLE `user_newsletters` (
-  `id` int NOT NULL AUTO_INCREMENT,
-  `user_id` int NOT NULL,
-  `newsletter_id` int NOT NULL,
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) NOT NULL,
+  `newsletter_id` int(11) NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB;
 
 CREATE TABLE `valuestore` (
-  `id` int NOT NULL AUTO_INCREMENT,
+  `id` int(11) NOT NULL AUTO_INCREMENT,
   `key` varchar(20) NOT NULL DEFAULT '',
   `value` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`)

--- a/test/sql/mysql.sql
+++ b/test/sql/mysql.sql
@@ -2,7 +2,7 @@
 SET SESSION sql_mode = 'NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES'
 
 
-CREATE TABLE authors(
+CREATE TABLE `authors` (
 	author_id INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
 	parent_author_id INT,
 	name VARCHAR(25) NOT NULL DEFAULT 'default_name',
@@ -16,7 +16,7 @@ CREATE TABLE authors(
 	mixedCaseField varchar(50)
 ) ENGINE=InnoDB;
 
-CREATE TABLE books(
+CREATE TABLE `books` (
 	book_id INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
 	Author_Id INT,
 	secondary_author_id INT,
@@ -25,12 +25,12 @@ CREATE TABLE books(
 	special NUMERIC(10,2) DEFAULT 0
 );
 
-CREATE TABLE publishers(
+CREATE TABLE `publishers` (
 	publisher_id INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
 	name VARCHAR(25) NOT NULL DEFAULT 'default_name'
 ) ENGINE=InnoDB;
 
-CREATE TABLE venues (
+CREATE TABLE `venues` (
 	Id int NOT NULL AUTO_INCREMENT PRIMARY KEY,
 	name varchar(50),
 	city varchar(60),
@@ -40,7 +40,7 @@ CREATE TABLE venues (
 	UNIQUE(name,address)
 );
 
-CREATE TABLE events (
+CREATE TABLE `events` (
 	id int NOT NULL auto_increment PRIMARY KEY,
 	venue_id int NULL,
 	host_id int NOT NULL,
@@ -49,19 +49,19 @@ CREATE TABLE events (
 	type varchar(15) default NULL
 );
 
-CREATE TABLE hosts(
+CREATE TABLE `hosts` (
 	id INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
 	name VARCHAR(25)
 );
 
-CREATE TABLE employees (
+CREATE TABLE `employees` (
 	id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
 	first_name VARCHAR(255) NOT NULL,
 	last_name VARCHAR(255) NOT NULL,
 	nick_name VARCHAR(255) NOT NULL
 );
 
-CREATE TABLE positions (
+CREATE TABLE `positions` (
 	id int NOT NULL AUTO_INCREMENT PRIMARY KEY,
 	employee_id int NOT NULL,
 	title VARCHAR(255) NOT NULL,
@@ -74,42 +74,42 @@ CREATE TABLE `rm-bldg`(
     `space out` VARCHAR(1) NOT NULL
 );
 
-CREATE TABLE awesome_people(
+CREATE TABLE `awesome_people` (
 	id int not null primary key auto_increment,
 	author_id int,
 	is_awesome int default 1
 );
 
-CREATE TABLE amenities(
+CREATE TABLE `amenities` (
   `amenity_id` int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY,
   `type` varchar(40) NOT NULL DEFAULT ''
 );
 
-CREATE TABLE property(
+CREATE TABLE `property` (
   `property_id` int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY
 );
 
-CREATE TABLE property_amenities(
+CREATE TABLE `property_amenities` (
   `id` int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY,
   `amenity_id` int(11) NOT NULL DEFAULT '0',
   `property_id` int(11) NOT NULL DEFAULT '0'
 );
 
-CREATE TABLE users (
+CREATE TABLE `users` (
     id INT NOT NULL AUTO_INCREMENT PRIMARY KEY
 ) ENGINE=InnoDB;
 
-CREATE TABLE newsletters (
+CREATE TABLE `newsletters` (
     id INT NOT NULL AUTO_INCREMENT PRIMARY KEY
 ) ENGINE=InnoDB;
 
-CREATE TABLE user_newsletters (
+CREATE TABLE `user_newsletters` (
     id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
     user_id INT NOT NULL,
     newsletter_id INT NOT NULL
 ) ENGINE=InnoDB;
 
-CREATE TABLE valuestore (
+CREATE TABLE `valuestore` (
   `id` INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
   `key` varchar(20) NOT NULL DEFAULT '',
   `value` varchar(255) NOT NULL DEFAULT ''

--- a/test/sql/mysql.sql
+++ b/test/sql/mysql.sql
@@ -1,3 +1,7 @@
+# Set our `sql_mode` for strict testing
+SET SESSION sql_mode = 'NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES'
+
+
 CREATE TABLE authors(
 	author_id INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
 	parent_author_id INT,

--- a/test/sql/mysql.sql
+++ b/test/sql/mysql.sql
@@ -8,7 +8,7 @@ CREATE TABLE `authors` (
   `name` varchar(25) NOT NULL DEFAULT 'default_name',
   `updated_at` datetime,
   `created_at` datetime,
-  some_Date date,
+  `some_date` date,
   `some_time` time,
   `some_text` text,
   `some_enum` enum('a','b','c'),
@@ -50,8 +50,8 @@ CREATE TABLE `events` (
   `host_id` int(11) NOT NULL,
   `title` varchar(60) NOT NULL,
   `description` varchar(50),
-  PRIMARY KEY (`id`),
-  `type` varchar(15) default NULL
+  `type` varchar(15) default NULL,
+  PRIMARY KEY (`id`)
 );
 
 CREATE TABLE `hosts` (

--- a/test/sql/mysql.sql
+++ b/test/sql/mysql.sql
@@ -3,7 +3,7 @@ SET SESSION sql_mode = 'NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES'
 
 
 CREATE TABLE `authors` (
-	author_id INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
+	author_id INT NOT NULL AUTO_INCREMENT,
 	parent_author_id INT,
 	name VARCHAR(25) NOT NULL DEFAULT 'default_name',
 	updated_at datetime,
@@ -13,59 +13,67 @@ CREATE TABLE `authors` (
 	some_text text,
 	some_enum enum('a','b','c'),
 	encrypted_password varchar(50),
-	mixedCaseField varchar(50)
+	mixedCaseField varchar(50),
+	PRIMARY KEY (`author_id`)
 ) ENGINE=InnoDB;
 
 CREATE TABLE `books` (
-	book_id INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
+	book_id INT NOT NULL AUTO_INCREMENT,
 	Author_Id INT,
 	secondary_author_id INT,
 	name VARCHAR(50),
 	numeric_test VARCHAR(10) DEFAULT '0',
-	special NUMERIC(10,2) DEFAULT 0
+	special NUMERIC(10,2) DEFAULT 0,
+	PRIMARY KEY (`book_id`)
 );
 
 CREATE TABLE `publishers` (
-	publisher_id INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
-	name VARCHAR(25) NOT NULL DEFAULT 'default_name'
+	publisher_id INT NOT NULL AUTO_INCREMENT,
+	name VARCHAR(25) NOT NULL DEFAULT 'default_name',
+	PRIMARY KEY (`publisher_id`)
 ) ENGINE=InnoDB;
 
 CREATE TABLE `venues` (
-	Id int NOT NULL AUTO_INCREMENT PRIMARY KEY,
+	id int NOT NULL AUTO_INCREMENT,
 	name varchar(50),
 	city varchar(60),
 	state char(2),
 	address varchar(50),
 	phone varchar(10) default NULL,
+	PRIMARY KEY (`id`),
 	UNIQUE(name,address)
 );
 
 CREATE TABLE `events` (
-	id int NOT NULL auto_increment PRIMARY KEY,
+	id int NOT NULL auto_increment,
 	venue_id int NULL,
 	host_id int NOT NULL,
 	title varchar(60) NOT NULL,
 	description varchar(50),
+	PRIMARY KEY (`id`),
 	type varchar(15) default NULL
 );
 
 CREATE TABLE `hosts` (
-	id INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
-	name VARCHAR(25)
+	id INT NOT NULL AUTO_INCREMENT,
+	name VARCHAR(25),
+	PRIMARY KEY (`id`)
 );
 
 CREATE TABLE `employees` (
-	id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+	id INT NOT NULL AUTO_INCREMENT,
 	first_name VARCHAR(255) NOT NULL,
 	last_name VARCHAR(255) NOT NULL,
-	nick_name VARCHAR(255) NOT NULL
+	nick_name VARCHAR(255) NOT NULL,
+	PRIMARY KEY (`id`)
 );
 
 CREATE TABLE `positions` (
-	id int NOT NULL AUTO_INCREMENT PRIMARY KEY,
+	id int NOT NULL AUTO_INCREMENT,
 	employee_id int NOT NULL,
 	title VARCHAR(255) NOT NULL,
-	active SMALLINT NOT NULL
+	active SMALLINT NOT NULL,
+	PRIMARY KEY (`id`)
 );
 
 CREATE TABLE `rm-bldg`(
@@ -75,42 +83,50 @@ CREATE TABLE `rm-bldg`(
 );
 
 CREATE TABLE `awesome_people` (
-	id int not null primary key auto_increment,
+	id int not null auto_increment,
 	author_id int,
-	is_awesome int default 1
+	is_awesome int default 1,
+	PRIMARY KEY (`id`)
 );
 
 CREATE TABLE `amenities` (
-  `amenity_id` int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY,
-  `type` varchar(40) NOT NULL DEFAULT ''
+  `amenity_id` int(11) NOT NULL AUTO_INCREMENT,
+  `type` varchar(40) NOT NULL DEFAULT '',
+  PRIMARY KEY (`amenity_id`)
 );
 
 CREATE TABLE `property` (
-  `property_id` int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY
+  `property_id` int(11) NOT NULL AUTO_INCREMENT,
+  PRIMARY KEY (`property_id`)
 );
 
 CREATE TABLE `property_amenities` (
-  `id` int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  `id` int(11) NOT NULL AUTO_INCREMENT,
   `amenity_id` int(11) NOT NULL DEFAULT '0',
-  `property_id` int(11) NOT NULL DEFAULT '0'
+  `property_id` int(11) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`id`)
 );
 
 CREATE TABLE `users` (
-    id INT NOT NULL AUTO_INCREMENT PRIMARY KEY
+    id INT NOT NULL AUTO_INCREMENT,
+	PRIMARY KEY (`id`)
 ) ENGINE=InnoDB;
 
 CREATE TABLE `newsletters` (
-    id INT NOT NULL AUTO_INCREMENT PRIMARY KEY
+    id INT NOT NULL AUTO_INCREMENT,
+	PRIMARY KEY (`id`)
 ) ENGINE=InnoDB;
 
 CREATE TABLE `user_newsletters` (
-    id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    id INT NOT NULL AUTO_INCREMENT,
     user_id INT NOT NULL,
-    newsletter_id INT NOT NULL
+    newsletter_id INT NOT NULL,
+	PRIMARY KEY (`id`)
 ) ENGINE=InnoDB;
 
 CREATE TABLE `valuestore` (
-  `id` INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  `id` INT NOT NULL AUTO_INCREMENT,
   `key` varchar(20) NOT NULL DEFAULT '',
-  `value` varchar(255) NOT NULL DEFAULT ''
+  `value` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (`id`)
 ) ENGINE=InnoDB;

--- a/test/sql/mysql.sql
+++ b/test/sql/mysql.sql
@@ -3,89 +3,89 @@ SET SESSION sql_mode = 'NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES'
 
 
 CREATE TABLE `authors` (
-  author_id INT NOT NULL AUTO_INCREMENT,
-  parent_author_id INT,
-  name VARCHAR(25) NOT NULL DEFAULT 'default_name',
-  updated_at datetime,
-  created_at datetime,
+  `author_id` int NOT NULL AUTO_INCREMENT,
+  `parent_author_id` int,
+  `name` varchar(25) NOT NULL DEFAULT 'default_name',
+  `updated_at` datetime,
+  `created_at` datetime,
   some_Date date,
-  some_time time,
-  some_text text,
-  some_enum enum('a','b','c'),
-  encrypted_password varchar(50),
-  mixedCaseField varchar(50),
+  `some_time` time,
+  `some_text` text,
+  `some_enum` enum('a','b','c'),
+  `encrypted_password` varchar(50),
+  `mixedCaseField` varchar(50),
   PRIMARY KEY (`author_id`)
 ) ENGINE=InnoDB;
 
 CREATE TABLE `books` (
-  book_id INT NOT NULL AUTO_INCREMENT,
-  Author_Id INT,
-  secondary_author_id INT,
-  name VARCHAR(50),
-  numeric_test VARCHAR(10) DEFAULT '0',
-  special NUMERIC(10,2) DEFAULT 0,
+  `book_id` int NOT NULL AUTO_INCREMENT,
+  `author_id` int,
+  `secondary_author_id` int,
+  `name` varchar(50),
+  `numeric_test` varchar(10) DEFAULT '0',
+  `special` numeric(10,2) DEFAULT 0,
   PRIMARY KEY (`book_id`)
 );
 
 CREATE TABLE `publishers` (
-  publisher_id INT NOT NULL AUTO_INCREMENT,
-  name VARCHAR(25) NOT NULL DEFAULT 'default_name',
+  `publisher_id` int NOT NULL AUTO_INCREMENT,
+  `name` varchar(25) NOT NULL DEFAULT 'default_name',
   PRIMARY KEY (`publisher_id`)
 ) ENGINE=InnoDB;
 
 CREATE TABLE `venues` (
-  id int NOT NULL AUTO_INCREMENT,
-  name varchar(50),
-  city varchar(60),
-  state char(2),
-  address varchar(50),
-  phone varchar(10) default NULL,
+  `id` int NOT NULL AUTO_INCREMENT,
+  `name` varchar(50),
+  `city` varchar(60),
+  `state` char(2),
+  `address` varchar(50),
+  `phone` varchar(10) default NULL,
   PRIMARY KEY (`id`),
   UNIQUE(name,address)
 );
 
 CREATE TABLE `events` (
-  id int NOT NULL auto_increment,
-  venue_id int NULL,
-  host_id int NOT NULL,
-  title varchar(60) NOT NULL,
-  description varchar(50),
+  `id` int NOT NULL AUTO_INCREMENT,
+  `venue_id` int NULL,
+  `host_id` int NOT NULL,
+  `title` varchar(60) NOT NULL,
+  `description` varchar(50),
   PRIMARY KEY (`id`),
-  type varchar(15) default NULL
+  `type` varchar(15) default NULL
 );
 
 CREATE TABLE `hosts` (
-  id INT NOT NULL AUTO_INCREMENT,
-  name VARCHAR(25),
+  `id` int NOT NULL AUTO_INCREMENT,
+  `name` varchar(25),
   PRIMARY KEY (`id`)
 );
 
 CREATE TABLE `employees` (
-  id INT NOT NULL AUTO_INCREMENT,
-  first_name VARCHAR(255) NOT NULL,
-  last_name VARCHAR(255) NOT NULL,
-  nick_name VARCHAR(255) NOT NULL,
+  `id` int NOT NULL AUTO_INCREMENT,
+  `first_name` varchar(255) NOT NULL,
+  `last_name` varchar(255) NOT NULL,
+  `nick_name` varchar(255) NOT NULL,
   PRIMARY KEY (`id`)
 );
 
 CREATE TABLE `positions` (
-  id int NOT NULL AUTO_INCREMENT,
-  employee_id int NOT NULL,
-  title VARCHAR(255) NOT NULL,
-  active SMALLINT NOT NULL,
+  `id` int NOT NULL AUTO_INCREMENT,
+  `employee_id` int NOT NULL,
+  `title` varchar(255) NOT NULL,
+  `active` smallint NOT NULL,
   PRIMARY KEY (`id`)
 );
 
 CREATE TABLE `rm-bldg`(
-  `rm-id` INT NOT NULL,
-  `rm-name` VARCHAR(10) NOT NULL,
-  `space out` VARCHAR(1) NOT NULL
+  `rm-id` int NOT NULL,
+  `rm-name` varchar(10) NOT NULL,
+  `space out` varchar(1) NOT NULL
 );
 
 CREATE TABLE `awesome_people` (
-  id int not null auto_increment,
-  author_id int,
-  is_awesome int default 1,
+  `id` int NOT NULL AUTO_INCREMENT,
+  `author_id` int,
+  `is_awesome` int default 1,
   PRIMARY KEY (`id`)
 );
 
@@ -108,24 +108,24 @@ CREATE TABLE `property_amenities` (
 );
 
 CREATE TABLE `users` (
-  id INT NOT NULL AUTO_INCREMENT,
+  `id` int NOT NULL AUTO_INCREMENT,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB;
 
 CREATE TABLE `newsletters` (
-  id INT NOT NULL AUTO_INCREMENT,
+  `id` int NOT NULL AUTO_INCREMENT,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB;
 
 CREATE TABLE `user_newsletters` (
-  id INT NOT NULL AUTO_INCREMENT,
-  user_id INT NOT NULL,
-  newsletter_id INT NOT NULL,
+  `id` int NOT NULL AUTO_INCREMENT,
+  `user_id` int NOT NULL,
+  `newsletter_id` int NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB;
 
 CREATE TABLE `valuestore` (
-  `id` INT NOT NULL AUTO_INCREMENT,
+  `id` int NOT NULL AUTO_INCREMENT,
   `key` varchar(20) NOT NULL DEFAULT '',
   `value` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`)

--- a/test/sql/mysql.sql
+++ b/test/sql/mysql.sql
@@ -3,90 +3,90 @@ SET SESSION sql_mode = 'NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES'
 
 
 CREATE TABLE `authors` (
-	author_id INT NOT NULL AUTO_INCREMENT,
-	parent_author_id INT,
-	name VARCHAR(25) NOT NULL DEFAULT 'default_name',
-	updated_at datetime,
-	created_at datetime,
-	some_Date date,
-	some_time time,
-	some_text text,
-	some_enum enum('a','b','c'),
-	encrypted_password varchar(50),
-	mixedCaseField varchar(50),
-	PRIMARY KEY (`author_id`)
+  author_id INT NOT NULL AUTO_INCREMENT,
+  parent_author_id INT,
+  name VARCHAR(25) NOT NULL DEFAULT 'default_name',
+  updated_at datetime,
+  created_at datetime,
+  some_Date date,
+  some_time time,
+  some_text text,
+  some_enum enum('a','b','c'),
+  encrypted_password varchar(50),
+  mixedCaseField varchar(50),
+  PRIMARY KEY (`author_id`)
 ) ENGINE=InnoDB;
 
 CREATE TABLE `books` (
-	book_id INT NOT NULL AUTO_INCREMENT,
-	Author_Id INT,
-	secondary_author_id INT,
-	name VARCHAR(50),
-	numeric_test VARCHAR(10) DEFAULT '0',
-	special NUMERIC(10,2) DEFAULT 0,
-	PRIMARY KEY (`book_id`)
+  book_id INT NOT NULL AUTO_INCREMENT,
+  Author_Id INT,
+  secondary_author_id INT,
+  name VARCHAR(50),
+  numeric_test VARCHAR(10) DEFAULT '0',
+  special NUMERIC(10,2) DEFAULT 0,
+  PRIMARY KEY (`book_id`)
 );
 
 CREATE TABLE `publishers` (
-	publisher_id INT NOT NULL AUTO_INCREMENT,
-	name VARCHAR(25) NOT NULL DEFAULT 'default_name',
-	PRIMARY KEY (`publisher_id`)
+  publisher_id INT NOT NULL AUTO_INCREMENT,
+  name VARCHAR(25) NOT NULL DEFAULT 'default_name',
+  PRIMARY KEY (`publisher_id`)
 ) ENGINE=InnoDB;
 
 CREATE TABLE `venues` (
-	id int NOT NULL AUTO_INCREMENT,
-	name varchar(50),
-	city varchar(60),
-	state char(2),
-	address varchar(50),
-	phone varchar(10) default NULL,
-	PRIMARY KEY (`id`),
-	UNIQUE(name,address)
+  id int NOT NULL AUTO_INCREMENT,
+  name varchar(50),
+  city varchar(60),
+  state char(2),
+  address varchar(50),
+  phone varchar(10) default NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE(name,address)
 );
 
 CREATE TABLE `events` (
-	id int NOT NULL auto_increment,
-	venue_id int NULL,
-	host_id int NOT NULL,
-	title varchar(60) NOT NULL,
-	description varchar(50),
-	PRIMARY KEY (`id`),
-	type varchar(15) default NULL
+  id int NOT NULL auto_increment,
+  venue_id int NULL,
+  host_id int NOT NULL,
+  title varchar(60) NOT NULL,
+  description varchar(50),
+  PRIMARY KEY (`id`),
+  type varchar(15) default NULL
 );
 
 CREATE TABLE `hosts` (
-	id INT NOT NULL AUTO_INCREMENT,
-	name VARCHAR(25),
-	PRIMARY KEY (`id`)
+  id INT NOT NULL AUTO_INCREMENT,
+  name VARCHAR(25),
+  PRIMARY KEY (`id`)
 );
 
 CREATE TABLE `employees` (
-	id INT NOT NULL AUTO_INCREMENT,
-	first_name VARCHAR(255) NOT NULL,
-	last_name VARCHAR(255) NOT NULL,
-	nick_name VARCHAR(255) NOT NULL,
-	PRIMARY KEY (`id`)
+  id INT NOT NULL AUTO_INCREMENT,
+  first_name VARCHAR(255) NOT NULL,
+  last_name VARCHAR(255) NOT NULL,
+  nick_name VARCHAR(255) NOT NULL,
+  PRIMARY KEY (`id`)
 );
 
 CREATE TABLE `positions` (
-	id int NOT NULL AUTO_INCREMENT,
-	employee_id int NOT NULL,
-	title VARCHAR(255) NOT NULL,
-	active SMALLINT NOT NULL,
-	PRIMARY KEY (`id`)
+  id int NOT NULL AUTO_INCREMENT,
+  employee_id int NOT NULL,
+  title VARCHAR(255) NOT NULL,
+  active SMALLINT NOT NULL,
+  PRIMARY KEY (`id`)
 );
 
 CREATE TABLE `rm-bldg`(
-    `rm-id` INT NOT NULL,
-    `rm-name` VARCHAR(10) NOT NULL,
-    `space out` VARCHAR(1) NOT NULL
+  `rm-id` INT NOT NULL,
+  `rm-name` VARCHAR(10) NOT NULL,
+  `space out` VARCHAR(1) NOT NULL
 );
 
 CREATE TABLE `awesome_people` (
-	id int not null auto_increment,
-	author_id int,
-	is_awesome int default 1,
-	PRIMARY KEY (`id`)
+  id int not null auto_increment,
+  author_id int,
+  is_awesome int default 1,
+  PRIMARY KEY (`id`)
 );
 
 CREATE TABLE `amenities` (
@@ -108,20 +108,20 @@ CREATE TABLE `property_amenities` (
 );
 
 CREATE TABLE `users` (
-    id INT NOT NULL AUTO_INCREMENT,
-	PRIMARY KEY (`id`)
+  id INT NOT NULL AUTO_INCREMENT,
+  PRIMARY KEY (`id`)
 ) ENGINE=InnoDB;
 
 CREATE TABLE `newsletters` (
-    id INT NOT NULL AUTO_INCREMENT,
-	PRIMARY KEY (`id`)
+  id INT NOT NULL AUTO_INCREMENT,
+  PRIMARY KEY (`id`)
 ) ENGINE=InnoDB;
 
 CREATE TABLE `user_newsletters` (
-    id INT NOT NULL AUTO_INCREMENT,
-    user_id INT NOT NULL,
-    newsletter_id INT NOT NULL,
-	PRIMARY KEY (`id`)
+  id INT NOT NULL AUTO_INCREMENT,
+  user_id INT NOT NULL,
+  newsletter_id INT NOT NULL,
+  PRIMARY KEY (`id`)
 ) ENGINE=InnoDB;
 
 CREATE TABLE `valuestore` (


### PR DESCRIPTION
(Re-targeted version of #490)

This PR sets the MySQL `sql_mode` to a strict setting for our tests.

We do this in two ways/places:
- Set it **globally** for Travis-CI, since we want all travis tests to be strict and we don't care about messing with the environment since its temporary anyway
- Set it for the **session** when testing locally, so that it doesn't change your local MySQL configuration semi-permanently (which may be used for other local DB's)

Setting the `sql_mode` in this way should make our testing more reliable and will most likely even restore the seemingly vanished bug described in #438 (that was originally fixed in #317 and then again in #440).