### PR TITLE
Model cast count as integer

### DIFF
--- a/lib/Model.php
+++ b/lib/Model.php
@@ -1464,7 +1464,7 @@ class Model
 		$table = static::table();
 		$sql = $table->options_to_sql($options);
 		$values = $sql->get_where_values();
-		return static::connection()->query_and_fetch_one($sql->to_s(),$values);
+		return (int) static::connection()->query_and_fetch_one($sql->to_s(),$values);
 	}
 
 	/**

--- a/test/ActiveRecordFindTest.php
+++ b/test/ActiveRecordFindTest.php
@@ -226,12 +226,12 @@ class ActiveRecordFindTest extends DatabaseTest
 
 	public function test_count()
 	{
-		$this->assert_equals(1,Author::count(1));
-		$this->assert_equals(2,Author::count(array(1,2)));
+		$this->assert_same(1,Author::count(1));
+		$this->assert_same(2,Author::count(array(1,2)));
 		$this->assert_true(Author::count() > 1);
-		$this->assert_equals(0,Author::count(array('conditions' => 'author_id=99999999999999')));
-		$this->assert_equals(2,Author::count(array('conditions' => 'author_id=1 or author_id=2')));
-		$this->assert_equals(1,Author::count(array('name' => 'Tito', 'author_id' => 1)));
+		$this->assert_same(0,Author::count(array('conditions' => 'author_id=99999999999999')));
+		$this->assert_same(2,Author::count(array('conditions' => 'author_id=1 or author_id=2')));
+		$this->assert_same(1,Author::count(array('name' => 'Tito', 'author_id' => 1)));
 	}
 
 	public function test_gh149_empty_count()


### PR DESCRIPTION
Not a big deal, but as I was writing some unit tests I figured this small glitch. 

Test:
```php
  $this->assertSame(3, App\Models\SomeModel::count());
```

Result:
```
Failed asserting that '3' is identical to 3.
```