### PR TITLE
Php activerecord tableconstructor

### DIFF
--- a/lib/Model.php
+++ b/lib/Model.php
@@ -279,6 +279,14 @@ class Model
 
 		$this->invoke_callback('after_construct',false);
 	}
+	
+	/**
+	 * Factory method to facilitate subclassing of Table if desired.
+	 */
+	public static function get_table($model_class_name)
+	{
+		return new Table($model_class_name);
+	}
 
 	/**
 	 * Magic method which delegates to read_attribute(). This handles firing off getter methods,

--- a/lib/Model.php
+++ b/lib/Model.php
@@ -283,7 +283,7 @@ class Model
 	/**
 	 * Factory method to facilitate subclassing of Table if desired.
 	 */
-	public static function get_table($model_class_name)
+	public static function make_table($model_class_name)
 	{
 		return new Table($model_class_name);
 	}

--- a/lib/Table.php
+++ b/lib/Table.php
@@ -391,7 +391,7 @@ class Table
 		$this->relationships[$relationship->attribute_name] = $relationship;
 	}
 
-	private function get_meta_data()
+	protected function get_meta_data()
 	{
 		// as more adapters are added probably want to do this a better way
 		// than using instanceof but gud enuff for now

--- a/lib/Table.php
+++ b/lib/Table.php
@@ -68,7 +68,7 @@ class Table
 		{
 			/* do not place set_assoc in constructor..it will lead to infinite loop due to
 			   relationships requesting the model's table, but the cache hasn't been set yet */
-			self::$cache[$model_class_name] = Model::get_table($model_class_name);
+			self::$cache[$model_class_name] = Model::make_table($model_class_name);
 			self::$cache[$model_class_name]->set_associations();
 		}
 

--- a/lib/Table.php
+++ b/lib/Table.php
@@ -68,7 +68,7 @@ class Table
 		{
 			/* do not place set_assoc in constructor..it will lead to infinite loop due to
 			   relationships requesting the model's table, but the cache hasn't been set yet */
-			self::$cache[$model_class_name] = new Table($model_class_name);
+			self::$cache[$model_class_name] = Model::get_table($model_class_name);
 			self::$cache[$model_class_name]->set_associations();
 		}
 


### PR DESCRIPTION
I'm working in an environment where setting and retrieving objects to/from cache can be somewhat complex, and I want to handle caching of table metadata in a way that is not easily done with the available cache adapter mechanism.

Currently, our adapter has to parse the $key string to identify which type data we're caching (ie. table meta data) which is a pretty brittle solution and does not support future cached components such as the Model.

If we were able to extend the Table class, we could override some of the methods (such as the get_meta_data method) to customize them to meet our caching needs.  

By adding the "make_table" factory method, we are able to able to subclass the Table class without affecting the rest of the calls to Table::load().  
