### PR TITLE
Changing private -> protected for extensibility

### DIFF
--- a/lib/Model.php
+++ b/lib/Model.php
@@ -85,35 +85,35 @@ class Model
 	 *
 	 * @var array
 	 */
-	private $attributes = array();
+	protected $attributes = array();
 
 	/**
 	 * Flag whether or not this model's attributes have been modified since it will either be null or an array of column_names that have been modified
 	 *
 	 * @var array
 	 */
-	private $__dirty = null;
+	protected $__dirty = null;
 
 	/**
 	 * Flag that determines of this model can have a writer method invoked such as: save/update/insert/delete
 	 *
 	 * @var boolean
 	 */
-	private $__readonly = false;
+	protected $__readonly = false;
 
 	/**
 	 * Array of relationship objects as model_attribute_name => relationship
 	 *
 	 * @var array
 	 */
-	private $__relationships = array();
+	protected $__relationships = array();
 
 	/**
 	 * Flag that determines if a call to save() should issue an insert or an update sql statement
 	 *
 	 * @var boolean
 	 */
-	private $__new_record = true;
+	protected $__new_record = true;
 
 	/**
 	 * Set to the name of the connection this {@link Model} should use.
@@ -671,7 +671,7 @@ class Model
 	 * @param array $delegate An array containing delegate data
 	 * @return delegated attribute name or null
 	 */
-	private function is_delegated($name, &$delegate)
+	protected function is_delegated($name, &$delegate)
 	{
 		if ($delegate['prefix'] != '')
 			$name = substr($name,strlen($delegate['prefix'])+1);
@@ -708,7 +708,7 @@ class Model
 	 * @throws \ActiveRecord\ReadOnlyException
 	 * @param string $method_name Name of method that was invoked on model for exception message
 	 */
-	private function verify_not_readonly($method_name)
+	protected function verify_not_readonly($method_name)
 	{
 		if ($this->is_readonly())
 			throw new ReadOnlyException(get_class($this), $method_name);
@@ -797,7 +797,7 @@ class Model
 	 * @param boolean $validate Set to true or false depending on if you want the validators to run or not
 	 * @return boolean True if the model was saved to the database otherwise false
 	 */
-	private function insert($validate=true)
+	protected function insert($validate=true)
 	{
 		$this->verify_not_readonly('insert');
 
@@ -858,7 +858,7 @@ class Model
 	 * @param boolean $validate Set to true or false depending on if you want the validators to run or not
 	 * @return boolean True if the model was saved to the database otherwise false
 	 */
-	private function update($validate=true)
+	protected function update($validate=true)
 	{
 		$this->verify_not_readonly('update');
 
@@ -1077,7 +1077,7 @@ class Model
 	 *
 	 * @return boolean True if passed validators otherwise false
 	 */
-	private function _validate()
+	protected function _validate()
 	{
 		require_once 'Validations.php';
 
@@ -1195,7 +1195,7 @@ class Model
 	 * @param array $attributes An array in the form array(name => value, ...)
 	 * @param boolean $guard_attributes Flag of whether or not protected/non-accessible attributes should be guarded
 	 */
-	private function set_attributes_via_mass_assignment(array &$attributes, $guard_attributes)
+	protected function set_attributes_via_mass_assignment(array &$attributes, $guard_attributes)
 	{
 		//access uninflected columns since that is what we would have in result set
 		$table = static::table();
@@ -1861,7 +1861,7 @@ class Model
 	 * @param array $options Options array for the serializer
 	 * @return string Serialized representation of the model
 	 */
-	private function serialize($type, $options)
+	protected function serialize($type, $options)
 	{
 		require_once 'Serialization.php';
 		$class = "ActiveRecord\\{$type}Serializer";
@@ -1876,7 +1876,7 @@ class Model
 	 * @param boolean $must_exist Set to true to raise an exception if the callback does not exist.
 	 * @return boolean True if invoked or null if not
 	 */
-	private function invoke_callback($method_name, $must_exist=true)
+	protected function invoke_callback($method_name, $must_exist=true)
 	{
 		return static::table()->callback->invoke($this,$method_name,$must_exist);
 	}

--- a/lib/Table.php
+++ b/lib/Table.php
@@ -15,7 +15,7 @@ namespace ActiveRecord;
  */
 class Table
 {
-	private static $cache = array();
+	protected static $cache = array();
 
 	public $class;
 	public $conn;
@@ -60,7 +60,7 @@ class Table
 	/**
 	 * List of relationships for this table.
 	 */
-	private $relationships = array();
+	protected $relationships = array();
 
 	public static function load($model_class_name)
 	{
@@ -276,7 +276,7 @@ class Table
 	 * @param $includes array eager load directives
 	 * @return void
 	 */
-	private function execute_eager_load($models=array(), $attrs=array(), $includes=array())
+	protected function execute_eager_load($models=array(), $attrs=array(), $includes=array())
 	{
 		if (!is_array($includes))
 			$includes = array($includes);
@@ -386,12 +386,12 @@ class Table
 	 *
 	 * @param Relationship $relationship a Relationship object
 	 */
-	private function add_relationship($relationship)
+	protected function add_relationship($relationship)
 	{
 		$this->relationships[$relationship->attribute_name] = $relationship;
 	}
 
-	private function get_meta_data()
+	protected function get_meta_data()
 	{
 		// as more adapters are added probably want to do this a better way
 		// than using instanceof but gud enuff for now
@@ -409,7 +409,7 @@ class Table
 	 * @param $map array Hash of used_name => real_name
 	 * @return array Array with any aliases replaced with their read field name
 	 */
-	private function map_names(&$hash, &$map)
+	protected function map_names(&$hash, &$map)
 	{
 		$ret = array();
 
@@ -423,7 +423,7 @@ class Table
 		return $ret;
 	}
 
-	private function &process_data($hash)
+	protected function &process_data($hash)
 	{
 		if (!$hash)
 			return $hash;
@@ -443,7 +443,7 @@ class Table
 		return $hash;
 	}
 
-	private function set_primary_key()
+	protected function set_primary_key()
 	{
 		if (($pk = $this->class->getStaticPropertyValue('pk',null)) || ($pk = $this->class->getStaticPropertyValue('primary_key',null)))
 			$this->pk = is_array($pk) ? $pk : array($pk);
@@ -459,7 +459,7 @@ class Table
 		}
 	}
 
-	private function set_table_name()
+	protected function set_table_name()
 	{
 		if (($table = $this->class->getStaticPropertyValue('table',null)) || ($table = $this->class->getStaticPropertyValue('table_name',null)))
 			$this->table = $table;
@@ -477,7 +477,7 @@ class Table
 			$this->db_name = $db;
 	}
 
-	private function set_cache()
+	protected function set_cache()
 	{
 		if (!Cache::$adapter)
 			return;
@@ -494,7 +494,7 @@ class Table
 		}
 	}
 
-	private function set_sequence_name()
+	protected function set_sequence_name()
 	{
 		if (!$this->conn->supports_sequences())
 			return;
@@ -503,7 +503,7 @@ class Table
 			$this->sequence = $this->conn->get_sequence_name($this->table,$this->pk[0]);
 	}
 
-	private function set_associations()
+	protected function set_associations()
 	{
 		require_once __DIR__ . '/Relationship.php';
 		$namespace = $this->class->getNamespaceName();
@@ -551,7 +551,7 @@ class Table
 	 *       'to'       => 'delegate_to_relationship',
 	 *       'prefix'	=> 'prefix')
 	 */
-	private function set_delegates()
+	protected function set_delegates()
 	{
 		$delegates = $this->class->getStaticPropertyValue('delegate',array());
 		$new = array();
@@ -591,7 +591,7 @@ class Table
 	/**
 	 * @deprecated Model.php now checks for get|set_ methods via method_exists so there is no need for declaring static g|setters.
 	 */
-	private function set_setters_and_getters()
+	protected function set_setters_and_getters()
 	{
 		$getters = $this->class->getStaticPropertyValue('getters', array());
 		$setters = $this->class->getStaticPropertyValue('setters', array());


### PR DESCRIPTION
Recently needed to extend Table.php and Model.php and it required us to convert private methods and properties to protected.  Figured it would be a good change for the project.