### PR TITLE
Fix timezone bug in active record DateTime creation

### DIFF
--- a/lib/Model.php
+++ b/lib/Model.php
@@ -461,7 +461,7 @@ class Model
 
 		// convert php's \DateTime to ours
 		if ($value instanceof \DateTime)
-			$value = new DateTime($value->format('Y-m-d H:i:s T'));
+			$value = new DateTime($value->format('Y-m-d H:i:s'), $value->getTimezone());
 
 		// make sure DateTime values know what model they belong to so
 		// dirty stuff works when calling set methods on the DateTime object


### PR DESCRIPTION
Previously ActiveRecord::DateTime object was created from
a PHP DateTime's formatted string ('Y-m-d h:i:s T'),
`T` represents a 3 letter time zone abbreviation.
And unfortunately UTC+08:00 and UTC-06:00 share a
same abbr. `CST`.
So our fix is to use the timezone information directly
fetched from PHP DateTime object without using any
formatting.