### PR TITLE
Remove unnecessary conversion (DateTime)

### DIFF
--- a/lib/Model.php
+++ b/lib/Model.php
@@ -460,7 +460,7 @@ class Model
 		}
 
 		// convert php's \DateTime to ours
-		if ($value instanceof \DateTime)
+		if (!($value instanceof DateTime) && $value instanceof \DateTime)
 			$value = new DateTime($value->format('Y-m-d H:i:s T'));
 
 		// make sure DateTime values know what model they belong to so

--- a/test/ActiveRecordWriteTest.php
+++ b/test/ActiveRecordWriteTest.php
@@ -424,4 +424,21 @@ class ActiveRecordWriteTest extends DatabaseTest
 		$this->assert_equals(1, $num_affected);
 		$this->assert_true(strpos(Author::table()->last_sql, 'ORDER BY name asc LIMIT 1') !== false);
 	}
+
+	public function test_update_native_datetime()
+	{
+		$author = Author::create(array('name' => 'Blah Blah'));
+		$native_datetime = new \DateTime('1983-12-05');
+		$author->some_date = $native_datetime;
+		$this->assert_false($native_datetime === $author->some_date);
+	}
+
+	public function test_update_our_datetime()
+	{
+		$author = Author::create(array('name' => 'Blah Blah'));
+		$our_datetime = new DateTime('1983-12-05');
+		$author->some_date = $our_datetime;
+		$this->assert_true($our_datetime === $author->some_date);
+	}
+
 };


### PR DESCRIPTION
This code remove unnecessary conversion.
And It is a workaround to fix timezone problem in Korea and Japan.
(`\Datetime` can't parse some timezone like `JCST` that used in 1912~1937)


