### PR TITLE
Bugfix - Explicit Time Zone assignment regression from #532

### DIFF
--- a/lib/Column.php
+++ b/lib/Column.php
@@ -171,7 +171,7 @@ class Column
 					return $value;
 
 				if ($value instanceof \DateTime)
-					return $date_class::createFromFormat('Y-m-d H:i:s T', $value->format('Y-m-d H:i:s T'), $value->getTimezone());
+					return $date_class::createFromFormat('Y-m-d H:i:s', $value->format('Y-m-d H:i:s'), $value->getTimezone());
 
 				return $connection->string_to_datetime($value);
 		}

--- a/lib/Column.php
+++ b/lib/Column.php
@@ -171,6 +171,9 @@ class Column
 					return $value;
 
 				if ($value instanceof \DateTime)
+					// NOTE!: The DateTime "format" used must not include a time-zone (name, abbreviation, etc) or offset.
+					// Including one will cause PHP to ignore the passed in time-zone in the 3rd argument.
+					// See bug: https://bugs.php.net/bug.php?id=61022
 					return $date_class::createFromFormat('Y-m-d H:i:s', $value->format('Y-m-d H:i:s'), $value->getTimezone());
 
 				return $connection->string_to_datetime($value);

--- a/lib/Column.php
+++ b/lib/Column.php
@@ -171,10 +171,11 @@ class Column
 					return $value;
 
 				if ($value instanceof \DateTime)
-					// NOTE!: The DateTime "format" used must not include a time-zone (name, abbreviation, etc) or offset.
-					// Including one will cause PHP to ignore the passed in time-zone in the 3rd argument.
-					// See bug: https://bugs.php.net/bug.php?id=61022
-					return $date_class::createFromFormat('Y-m-d H:i:s', $value->format('Y-m-d H:i:s'), $value->getTimezone());
+					return $date_class::createFromFormat(
+						Connection::DATETIME_TRANSLATE_FORMAT,
+						$value->format(Connection::DATETIME_TRANSLATE_FORMAT),
+						$value->getTimezone()
+					);
 
 				return $connection->string_to_datetime($value);
 		}

--- a/lib/Connection.php
+++ b/lib/Connection.php
@@ -21,6 +21,17 @@ abstract class Connection
 {
 
 	/**
+	 * The DateTime format to use when translating other DateTime-compatible objects.
+	 *
+	 * NOTE!: The DateTime "format" used must not include a time-zone (name, abbreviation, etc) or offset.
+	 * Including one will cause PHP to ignore the passed in time-zone in the 3rd argument.
+	 * See bug: https://bugs.php.net/bug.php?id=61022
+	 *
+	 * @var string
+	 */
+	const DATETIME_TRANSLATE_FORMAT = 'Y-m-d\TH:i:s';
+
+	/**
 	 * The PDO connection object.
 	 * @var mixed
 	 */
@@ -480,7 +491,12 @@ abstract class Connection
 			return null;
 
 		$date_class = Config::instance()->get_date_class();
-		return $date_class::createFromFormat(static::$datetime_format, $date->format(static::$datetime_format));
+
+		return $date_class::createFromFormat(
+			static::DATETIME_TRANSLATE_FORMAT,
+			$date->format(static::DATETIME_TRANSLATE_FORMAT),
+			$date->getTimezone()
+		);
 	}
 
 	/**

--- a/lib/DateTime.php
+++ b/lib/DateTime.php
@@ -123,7 +123,7 @@ class DateTime extends \DateTime implements DateTimeInterface
 		if (!$phpDate)
 			return false;
 		// convert to this class using the timestamp
-		$ourDate = new static;
+		$ourDate = new static(null, $phpDate->getTimezone());
 		$ourDate->setTimestamp($phpDate->getTimestamp());
 		return $ourDate;
 	}

--- a/lib/Model.php
+++ b/lib/Model.php
@@ -463,10 +463,11 @@ class Model
 		if ($value instanceof \DateTime) {
 			$date_class = Config::instance()->get_date_class();
 			if (!($value instanceof $date_class))
-				// NOTE!: The DateTime "format" used must not include a time-zone (name, abbreviation, etc) or offset.
-				// Including one will cause PHP to ignore the passed in time-zone in the 3rd argument.
-				// See bug: https://bugs.php.net/bug.php?id=61022
-				$value = $date_class::createFromFormat('Y-m-d H:i:s', $value->format('Y-m-d H:i:s'), $value->getTimezone());
+				$value = $date_class::createFromFormat(
+					Connection::DATETIME_TRANSLATE_FORMAT,
+					$value->format(Connection::DATETIME_TRANSLATE_FORMAT),
+					$value->getTimezone()
+				);
 		}
 
 		if ($value instanceof DateTimeInterface)

--- a/lib/Model.php
+++ b/lib/Model.php
@@ -463,7 +463,7 @@ class Model
 		if ($value instanceof \DateTime) {
 			$date_class = Config::instance()->get_date_class();
 			if (!($value instanceof $date_class))
-				$value = $date_class::createFromFormat('Y-m-d H:i:s T', $value->format('Y-m-d H:i:s T'), $value->getTimezone());
+				$value = $date_class::createFromFormat('Y-m-d H:i:s', $value->format('Y-m-d H:i:s'), $value->getTimezone());
 		}
 
 		if ($value instanceof DateTimeInterface)

--- a/lib/Model.php
+++ b/lib/Model.php
@@ -463,6 +463,9 @@ class Model
 		if ($value instanceof \DateTime) {
 			$date_class = Config::instance()->get_date_class();
 			if (!($value instanceof $date_class))
+				// NOTE!: The DateTime "format" used must not include a time-zone (name, abbreviation, etc) or offset.
+				// Including one will cause PHP to ignore the passed in time-zone in the 3rd argument.
+				// See bug: https://bugs.php.net/bug.php?id=61022
 				$value = $date_class::createFromFormat('Y-m-d H:i:s', $value->format('Y-m-d H:i:s'), $value->getTimezone());
 		}
 

--- a/test/ColumnTest.php
+++ b/test/ColumnTest.php
@@ -126,5 +126,33 @@ class ColumnTest extends SnakeCase_PHPUnit_Framework_TestCase
 		$this->assert_equals(null,$column->cast(null,$this->conn));
 		$this->assert_equals(null,$column->cast('',$this->conn));
 	}
+
+	public function test_native_date_time_attribute_copies_exact_tz()
+	{
+		$dt = new \DateTime(null, new \DateTimeZone('America/New_York'));
+
+		$column = new Column();
+		$column->type = Column::DATETIME;
+
+		$dt2 = $column->cast($dt, $this->conn);
+
+		$this->assert_equals($dt->getTimestamp(), $dt2->getTimestamp());
+		$this->assert_equals($dt->getTimeZone(), $dt2->getTimeZone());
+		$this->assert_equals($dt->getTimeZone()->getName(), $dt2->getTimeZone()->getName());
+	}
+
+	public function test_ar_date_time_attribute_copies_exact_tz()
+	{
+		$dt = new DateTime(null, new \DateTimeZone('America/New_York'));
+
+		$column = new Column();
+		$column->type = Column::DATETIME;
+
+		$dt2 = $column->cast($dt, $this->conn);
+
+		$this->assert_equals($dt->getTimestamp(), $dt2->getTimestamp());
+		$this->assert_equals($dt->getTimeZone(), $dt2->getTimeZone());
+		$this->assert_equals($dt->getTimeZone()->getName(), $dt2->getTimeZone()->getName());
+	}
 }
 ?>

--- a/test/DateTimeTest.php
+++ b/test/DateTimeTest.php
@@ -147,5 +147,33 @@ class DateTimeTest extends SnakeCase_PHPUnit_Framework_TestCase
 		$d = DateTime::createFromFormat('Y-m-d H:i:s', '2000-02-01 03:04:05', new \DateTimeZone('Etc/GMT-10'));
 		$this->assert_equals(new DateTime('2000-01-31 17:04:05'), $d);
 	}
+
+	public function test_native_date_time_attribute_copies_exact_tz()
+	{
+		$dt = new \DateTime(null, new \DateTimeZone('America/New_York'));
+		$model = new Author();
+
+		// Test that the data transforms without modification
+		$model->assign_attribute('updated_at', $dt);
+		$dt2 = $model->read_attribute('updated_at');
+
+		$this->assert_equals($dt->getTimestamp(), $dt2->getTimestamp());
+		$this->assert_equals($dt->getTimeZone(), $dt2->getTimeZone());
+		$this->assert_equals($dt->getTimeZone()->getName(), $dt2->getTimeZone()->getName());
+	}
+
+	public function test_ar_date_time_attribute_copies_exact_tz()
+	{
+		$dt = new DateTime(null, new \DateTimeZone('America/New_York'));
+		$model = new Author();
+
+		// Test that the data transforms without modification
+		$model->assign_attribute('updated_at', $dt);
+		$dt2 = $model->read_attribute('updated_at');
+
+		$this->assert_equals($dt->getTimestamp(), $dt2->getTimestamp());
+		$this->assert_equals($dt->getTimeZone(), $dt2->getTimeZone());
+		$this->assert_equals($dt->getTimeZone()->getName(), $dt2->getTimeZone()->getName());
+	}
 }
 ?>

--- a/test/DateTimeTest.php
+++ b/test/DateTimeTest.php
@@ -145,7 +145,9 @@ class DateTimeTest extends SnakeCase_PHPUnit_Framework_TestCase
 	public function test_create_from_format_with_tz()
 	{
 		$d = DateTime::createFromFormat('Y-m-d H:i:s', '2000-02-01 03:04:05', new \DateTimeZone('Etc/GMT-10'));
-		$this->assert_equals(new DateTime('2000-01-31 17:04:05'), $d);
+		$d2 = new DateTime('2000-01-31 17:04:05');
+
+		$this->assert_equals($d2->getTimestamp(), $d->getTimestamp());
 	}
 
 	public function test_native_date_time_attribute_copies_exact_tz()


### PR DESCRIPTION
So PR #533 was fantastic in fixing an issue regarding passing in an explicit time-zone during column casting and attribute assigning. Unfortunately, the merge of #532 caused a regression as it overwrote the fix made in #533. 😞 

This PR fixes that regression.

The included test makes sure the behavior is correct, and the following snippet demonstrates the issue at hand:

![screen shot 2016-05-19 at 12 05 55 pm](https://cloud.githubusercontent.com/assets/742384/15400619/2342e144-1dba-11e6-90f9-d35b3aaa3152.png)
