### PR TITLE
Duplicate conditional expression in Validations.php

### DIFF
--- a/lib/Validations.php
+++ b/lib/Validations.php
@@ -422,7 +422,7 @@ class Validations
 			$attribute = $options[0];
 			$var = $this->model->$attribute;
 
-			if (is_null($options['with']) || !is_string($options['with']) || !is_string($options['with']))
+			if (is_null($options['with']) || !is_string($options['with']))
 				throw new ValidationsArgumentError('A regular expression must be supplied as the [with] option of the configuration array.');
 			else
 				$expression = $options['with'];


### PR DESCRIPTION
`!is_string($options['with'])` is repeated.