### PR TITLE
Potential fix for issue #546

### DIFF
--- a/lib/Relationship.php
+++ b/lib/Relationship.php
@@ -289,7 +289,7 @@ abstract class AbstractRelationship implements InterfaceRelationship
 		if (!has_absolute_namespace($class_name) && isset($this->options['namespace'])) {
 			$class_name = $this->options['namespace'].'\\'.$class_name;
 		}
-		
+
 		$reflection = Reflections::instance()->add($class_name)->get($class_name);
 
 		if (!$reflection->isSubClassOf('ActiveRecord\\Model'))
@@ -505,7 +505,7 @@ class HasMany extends AbstractRelationship
 				$fk = $this->foreign_key;
 
 				$this->set_keys($this->get_table()->class->getName(), true);
-				
+
 				$class = $this->class_name;
 				$relation = $class::table()->get_relationship($this->through);
 				$through_table = $relation->get_table();

--- a/lib/Relationship.php
+++ b/lib/Relationship.php
@@ -725,4 +725,13 @@ class BelongsTo extends AbstractRelationship
 	{
 		$this->query_and_attach_related_models_eagerly($table,$models,$attributes,$includes, $this->primary_key,$this->foreign_key);
 	}
+
+	// Unlike the other relationships, a belongs_to stores its foreign key on the associate (and not
+	// on the new record). Therewfore, we must override the append_record_to_associate behaviour of
+	// AbstractRelationship to provide this behaviour.
+	protected function append_record_to_associate(Model $associate, Model $record)
+	{
+		$associate->{$this->foreign_key[0]} = $record->id;
+		return $record;
+	}
 }

--- a/test/RelationshipTest.php
+++ b/test/RelationshipTest.php
@@ -23,7 +23,7 @@ class RelationshipTest extends DatabaseTest
 		Venue::$has_one = array();
 		Employee::$has_one = array(array('position'));
 		Host::$has_many = array(array('events', 'order' => 'id asc'));
-		
+
 		foreach ($this->relationship_names as $name)
 		{
 			if (preg_match("/$name/", $this->getName(), $match))
@@ -80,26 +80,26 @@ class RelationshipTest extends DatabaseTest
 	{
 		$this->assert_default_has_many($this->get_relationship());
 	}
-	
+
 	public function test_gh_256_eager_loading_three_levels_deep()
 	{
 		/* Before fix Undefined offset: 0 */
 		$conditions['include'] = array('events'=>array('host'=>array('events')));
 		$venue = Venue::find(2,$conditions);
-		
+
 		$events = $venue->events;
 		$this->assertEquals(2,count($events));
 		$event_yeah_yeahs = $events[0];
 		$this->assertEquals('Yeah Yeah Yeahs',$event_yeah_yeahs->title);
-		
+
 		$event_host = $event_yeah_yeahs->host;
 		$this->assertEquals('Billy Crystal',$event_host->name);
-		
+
 		$bill_events = $event_host->events;
-		
+
 		$this->assertEquals('Yeah Yeah Yeahs',$bill_events[0]->title);
 	}
-	
+
 	/**
 	 * @expectedException ActiveRecord\RelationshipException
 	 */

--- a/test/RelationshipTest.php
+++ b/test/RelationshipTest.php
@@ -230,6 +230,15 @@ class RelationshipTest extends DatabaseTest
 		$this->assert_not_null($venue->id);
 	}
 
+	public function test_belongs_to_create_association_sets_foreign_key()
+	{
+		$event = $this->get_relationship();
+		$values = array('city' => 'Richmond', 'state' => 'VA', 'name' => 'Club 54', 'address' => '123 street');
+		$venue = $event->create_venue($values);
+
+		$this->assert_equals($venue->id, $event->venue_id);
+	}
+
 	public function test_build_association_overwrites_guarded_foreign_keys()
 	{
 		$author = new AuthorAttrAccessible();


### PR DESCRIPTION
As discussed in #546, I was seeing an issue whereby foreign key attributes where not being set during a `create_association` for a `belongs_to`.

This is one potential fix: it overrides the `append_record_to_associate` (which was shared for all types of relationship) for belongs to relationships such that the foreign key is set on the associate, and not on the new record.