### PR TITLE
Add support for SQLite :memory: databases.

### DIFF
--- a/lib/Connection.php
+++ b/lib/Connection.php
@@ -178,7 +178,7 @@ abstract class Connection
 	{
 		$url = @parse_url($connection_url);
 
-		if ( $url['scheme'] == "sqlite" && $url['host'] == ":memory" )
+		if ($url['scheme'] == "sqlite" && $url['host'] == ":memory")
 			$url['host'] = ":memory:";
 
 		if (!isset($url['host']))

--- a/lib/Connection.php
+++ b/lib/Connection.php
@@ -168,6 +168,7 @@ abstract class Connection
 	 * sqlite://../relative/path/to/file.db
 	 * sqlite://unix(/absolute/path/to/file.db)
 	 * sqlite://windows(c%2A/absolute/path/to/file.db)
+	 * sqlite://:memory:
 	 * </code>
 	 *
 	 * @param string $connection_url A connection URL
@@ -176,6 +177,9 @@ abstract class Connection
 	public static function parse_connection_url($connection_url)
 	{
 		$url = @parse_url($connection_url);
+
+		if ( $url['scheme'] == "sqlite" && $url['host'] == ":memory" )
+			$url['host'] = ":memory:";
 
 		if (!isset($url['host']))
 			throw new DatabaseException('Database host must be specified in the connection string. If you want to specify an absolute filename, use e.g. sqlite://unix(/path/to/file)');

--- a/lib/adapters/SqliteAdapter.php
+++ b/lib/adapters/SqliteAdapter.php
@@ -15,13 +15,17 @@ class SqliteAdapter extends Connection
 {
 
 	static $datetime_format = 'Y-m-d H:i:s';
+	private static $cached_connection;
 
 	protected function __construct($info)
 	{
-		if (!file_exists($info->host))
+		if ($info->host != ":memory:" && !file_exists($info->host))
 			throw new DatabaseException("Could not find sqlite db: $info->host");
 
-		$this->connection = new PDO("sqlite:$info->host",null,null,static::$PDO_OPTIONS);
+		if ( self::$cached_connection == null ) {
+			self::$cached_connection = new PDO("sqlite:$info->host",null,null,static::$PDO_OPTIONS);
+		}
+		$this->connection = self::$cached_connection;
 	}
 
 	public function limit($sql, $offset, $limit)

--- a/lib/adapters/SqliteAdapter.php
+++ b/lib/adapters/SqliteAdapter.php
@@ -22,7 +22,7 @@ class SqliteAdapter extends Connection
 		if ($info->host != ":memory:" && !file_exists($info->host))
 			throw new DatabaseException("Could not find sqlite db: $info->host");
 
-		if ( self::$cached_connection == null ) {
+		if (self::$cached_connection == null) {
 			self::$cached_connection = new PDO("sqlite:$info->host",null,null,static::$PDO_OPTIONS);
 		}
 		$this->connection = self::$cached_connection;

--- a/test/SqliteAdapterMemoryTest.php
+++ b/test/SqliteAdapterMemoryTest.php
@@ -1,0 +1,30 @@
+<?php
+require_once __DIR__ . '/../lib/adapters/SqliteAdapter.php';
+require_once __DIR__ . '/SqliteAdapterTest.php';
+
+class SqliteAdapterMemoryTest extends SqliteAdapterTest
+{
+	public function set_up($connection_name=null)
+	{
+		$connections = ActiveRecord\Config::instance()->get_connections();
+    $connections['sqlite'] = 'sqlite://:memory:';
+		ActiveRecord\Config::instance()->set_connections( $connections );
+
+		parent::set_up();
+	}
+
+	public function testConnectToMemoryDatabaseShouldNotCreateDbFile()
+	{
+		try
+		{
+			ActiveRecord\Connection::instance("sqlite://:memory:");
+			$this->assertFalse(file_exists(__DIR__ . "/" . ":memory:" ));
+		}
+		catch (ActiveRecord\DatabaseException $e)
+		{
+			$this->assertFalse(true);
+		}
+	}
+
+}
+?>

--- a/test/SqliteAdapterMemoryTest.php
+++ b/test/SqliteAdapterMemoryTest.php
@@ -8,7 +8,7 @@ class SqliteAdapterMemoryTest extends SqliteAdapterTest
 	{
 		$connections = ActiveRecord\Config::instance()->get_connections();
     $connections['sqlite'] = 'sqlite://:memory:';
-		ActiveRecord\Config::instance()->set_connections( $connections );
+		ActiveRecord\Config::instance()->set_connections($connections);
 
 		parent::set_up();
 	}
@@ -18,7 +18,7 @@ class SqliteAdapterMemoryTest extends SqliteAdapterTest
 		try
 		{
 			ActiveRecord\Connection::instance("sqlite://:memory:");
-			$this->assertFalse(file_exists(__DIR__ . "/" . ":memory:" ));
+			$this->assertFalse(file_exists(__DIR__ . "/" . ":memory:"));
 		}
 		catch (ActiveRecord\DatabaseException $e)
 		{

--- a/test/SqliteAdapterMemoryTest.php
+++ b/test/SqliteAdapterMemoryTest.php
@@ -22,7 +22,7 @@ class SqliteAdapterMemoryTest extends SqliteAdapterTest
 		}
 		catch (ActiveRecord\DatabaseException $e)
 		{
-			$this->assertFalse(true);
+			$this->fail("could not open connection to :memory: database");
 		}
 	}
 


### PR DESCRIPTION
These were some fairly simple changes that don't really _add_ support for SQLite `:memory:` databases, so much as they _unlock_ support for them.

**Use Case:**
Unit testing code that uses PHP-AR without relying on a live db connection.  I can use `sqlite://:memory:` for my `testing` environment, run migrations in my test `set_up()`, then run tests.  Super fast. ⚡ 

**Notes:**
- $cached_connection was needed in SqliteAdapter so that a new, empty db wasn’t created on every call to a Model.
- Added tests for `:memory:` databases by just running all SQLite tests again with `sqlite://:memory:` as DSN instead of `sqlite://test.db`.  It would be good for someone to confirm that this is really testing what it should be testing.
- I did not setup OCI for testing, but all other adapters passed tests.
