### PR TITLE
Make indirect variable explicit for PHP 7

### DIFF
--- a/lib/Model.php
+++ b/lib/Model.php
@@ -426,7 +426,7 @@ class Model
 		foreach (static::$delegate as &$item)
 		{
 			if (($delegated_name = $this->is_delegated($name,$item)))
-				return $this->$item['to']->$delegated_name = $value;
+				return $this->{$item['to']}->{$delegated_name} = $value;
 		}
 
 		throw new UndefinedPropertyException(get_called_class(),$name);


### PR DESCRIPTION
Fixes two failing tests (`ActiveRecordTest::test_delegate_set_attribute` and `test_delegate_setter_gh_98`) on master under PHP7 by making the interpretation of `$this->$item['to']->$delegated_name` explicit.

PHP 7 interprets this as `($this->item)['to']->$delegated_name`, we want it to mean `$this->{$item['to']}->$delegated_name`.

See http://php.net/manual/en/migration70.incompatible.php for the change in PHP behaviour
