### PR TITLE
Add PHP7 to Travis with failures allowed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,13 @@ php:
   - 5.3
   - 5.4
   - 5.5
+  - 7.0
+  - 7.1
+
+matrix:
+  allow_failures:
+    - php: 7.0
+    - php: 7.1
+  fast_finish: true
 
 script: ./vendor/bin/phpunit


### PR DESCRIPTION
Please note this curently fails for master (see #553) and spits out a whole bunch of deprecation warnings.

There also seems to be an issue with the memcached module missing in the Travis PHP 7.0 environment, I'm not seeing that problem here locally as I've manually installed memcached.

I've set it to allow failures for PHP 7, so full PHP 7 compatibility can be monitored without ruining the happy green badges. Of course I'm hoping the `allow_failures` setting can be removed soon ;)
