### PR TITLE
updated activerecord_autoload 

### DIFF
--- a/ActiveRecord.php
+++ b/ActiveRecord.php
@@ -45,6 +45,12 @@ function activerecord_autoload($class_name)
 
 	$file = "$root/$class_name.php";
 
-	if (file_exists($file))
+	if(file_exists($file)) {
 		require_once $file;
+	} else {
+		$file = "$root/".\ActiveRecord\Inflector::instance()->uncamelize($class_name).".php";
+		if(file_exists($file)) {
+			require_once $file;
+		}
+	}
 }


### PR DESCRIPTION
if file not found then try to uncamelize class_name.  

Example:
UserProfile class would have to load UserProfile.php which still works but with this patch UserProfile class could load the filename user_profile.php. 
