### PR TITLE
Invalid index when including empty array as nested includes.

### DIFF
--- a/lib/Table.php
+++ b/lib/Table.php
@@ -286,7 +286,7 @@ class Table
 			// nested include
 			if (is_array($name))
 			{
-				$nested_includes = count($name) > 0 ? $name : $name[0];
+				$nested_includes = count($name) > 0 ? $name : array();
 				$name = $index;
 			}
 			else

--- a/test/RelationshipTest.php
+++ b/test/RelationshipTest.php
@@ -84,9 +84,9 @@ class RelationshipTest extends DatabaseTest
 	public function test_eager_load_with_empty_nested_includes()
 	{
 		$conditions['include'] = array('events'=>array());
-		Venue::find(2,$conditions);
+		Venue::find(2, $conditions);
 
-        $this->assert_sql_has("WHERE venue_id IN(?)",ActiveRecord\Table::load('Event')->last_sql);
+		$this->assert_sql_has("WHERE venue_id IN(?)", ActiveRecord\Table::load('Event')->last_sql);
 	}
 
     public function test_gh_256_eager_loading_three_levels_deep()

--- a/test/RelationshipTest.php
+++ b/test/RelationshipTest.php
@@ -81,24 +81,32 @@ class RelationshipTest extends DatabaseTest
 		$this->assert_default_has_many($this->get_relationship());
 	}
 	
-	public function test_gh_256_eager_loading_three_levels_deep()
+	public function test_eager_load_with_empty_nested_includes()
 	{
-		/* Before fix Undefined offset: 0 */
-		$conditions['include'] = array('events'=>array('host'=>array('events')));
-		$venue = Venue::find(2,$conditions);
-		
-		$events = $venue->events;
-		$this->assertEquals(2,count($events));
-		$event_yeah_yeahs = $events[0];
-		$this->assertEquals('Yeah Yeah Yeahs',$event_yeah_yeahs->title);
-		
-		$event_host = $event_yeah_yeahs->host;
-		$this->assertEquals('Billy Crystal',$event_host->name);
-		
-		$bill_events = $event_host->events;
-		
-		$this->assertEquals('Yeah Yeah Yeahs',$bill_events[0]->title);
+		$conditions['include'] = array('events'=>array());
+		Venue::find(2,$conditions);
+
+        $this->assert_sql_has("WHERE venue_id IN(?)",ActiveRecord\Table::load('Event')->last_sql);
 	}
+
+    public function test_gh_256_eager_loading_three_levels_deep()
+    {
+        /* Before fix Undefined offset: 0 */
+        $conditions['include'] = array('events'=>array('host'=>array('events')));
+        $venue = Venue::find(2,$conditions);
+
+        $events = $venue->events;
+        $this->assertEquals(2,count($events));
+        $event_yeah_yeahs = $events[0];
+        $this->assertEquals('Yeah Yeah Yeahs',$event_yeah_yeahs->title);
+
+        $event_host = $event_yeah_yeahs->host;
+        $this->assertEquals('Billy Crystal',$event_host->name);
+
+        $bill_events = $event_host->events;
+
+        $this->assertEquals('Yeah Yeah Yeahs',$bill_events[0]->title);
+    }
 	
 	/**
 	 * @expectedException ActiveRecord\RelationshipException


### PR DESCRIPTION
The logic here is slightly faulty, such that you will _always_ get a `Notice: Undefined offset: 0` error if passing an empty array as a nested include.

For example:
```php
// Won't fail:
$book_includes = [
  'author',
  'library' => [
    'city',
  ],
];

// Will fail:
$book_includes = [
  'author' => [],
  'library' => [
    'city' => [],
  ],
];
```

Expected behavior should be that an empty array of nested includes sets the `$name` as `$index` and sets the `$nested_includes` to an empty array.