### PR TITLE
Fix drop_connection for the default connection

### DIFF
--- a/lib/ConnectionManager.php
+++ b/lib/ConnectionManager.php
@@ -39,10 +39,15 @@ class ConnectionManager extends Singleton
 	 * Drops the connection from the connection manager. Does not actually close it since there
 	 * is no close method in PDO.
 	 *
+	 * If $name is null then the default connection will be returned.
+	 *
 	 * @param string $name Name of the connection to forget about
 	 */
 	public static function drop_connection($name=null)
 	{
+		$config = Config::instance();
+		$name = $name ? $name : $config->get_default_connection();
+
 		if (isset(self::$connections[$name]))
 			unset(self::$connections[$name]);
 	}


### PR DESCRIPTION
While `get_connection()` used `get_default_connection()` if there is no specific connection,
(aka `$name = null`) , `drop_connection()` didn't and therefore did not drop a connection
if no specific name was given.

In `Table::reestablish_connection()` the connection (name) is retrieved like this:

    $connection = $this->class->getStaticPropertyValue('connection',null);

This meant that if no static property 'connection' is set, the `$connection` will be `null`.
This should mean that the default connection is use, but currently nothing will be
dropped, which is a bug.
This fix changes that, so that if the default connection is used, the default connection is dropped.

An alternative might have been to change this in the call
(`Table::reestablish_connection()` for instance), but it seems to me that keeping
`drop_connection`'s behaviour the same as `get_connection()` is the best way.