### PR TITLE
Fixed the DateTime method declaration to use microseconds for php7

### DIFF
--- a/lib/DateTime.php
+++ b/lib/DateTime.php
@@ -165,7 +165,7 @@ class DateTime extends \DateTime implements DateTimeInterface
 		return parent::setISODate($year, $week, $day);
 	}
 
-	public function setTime($hour, $minute, $second = 0)
+	public function setTime($hour, $minute, $second = 0, $microseconds = null)
 	{
 		$this->flag_dirty();
 		return parent::setTime($hour, $minute, $second);


### PR DESCRIPTION
In PHP7.3 there was a change made to the static setTime method of the DateTime class. This fixes that issue to ignore the extra "microseconds" parameter which was preventing the library from being compatible with PHP7 and above. 