### PR TITLE
Add support for PHP 7.1 DateTime::setTime with microseconds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,3 @@
 vendor/*
 composer.lock
 phpunit.xml
-
-.idea

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 vendor/*
 composer.lock
 phpunit.xml
+
+.idea

--- a/lib/DateTime.php
+++ b/lib/DateTime.php
@@ -165,10 +165,10 @@ class DateTime extends \DateTime implements DateTimeInterface
 		return parent::setISODate($year, $week, $day);
 	}
 
-	public function setTime($hour, $minute, $second = 0)
+	public function setTime($hour, $minute, $second = 0, $microseconds = 0)
 	{
 		$this->flag_dirty();
-		return parent::setTime($hour, $minute, $second);
+        return parent::setTime($hour, $minute, $second);
 	}
 
 	public function setTimestamp($unixtimestamp)

--- a/lib/DateTime.php
+++ b/lib/DateTime.php
@@ -168,7 +168,7 @@ class DateTime extends \DateTime implements DateTimeInterface
 	public function setTime($hour, $minute, $second = 0, $microseconds = 0)
 	{
 		$this->flag_dirty();
-        return parent::setTime($hour, $minute, $second);
+		return parent::setTime($hour, $minute, $second);
 	}
 
 	public function setTimestamp($unixtimestamp)

--- a/test/DateTimeTest.php
+++ b/test/DateTimeTest.php
@@ -75,6 +75,17 @@ class DateTimeTest extends SnakeCase_PHPUnit_Framework_TestCase
 		$this->assert_datetime_equals($a,$b);
 	}
 
+    public function test_set_time_microseconds()
+    {
+        $a = new \DateTime();
+        $a->setTime(1, 1, 1);
+
+        $b = new DateTime();
+        $b->setTime(1, 1, 1, 0);
+
+        $this->assert_datetime_equals($a,$b);
+	}
+
 	public function test_get_format_with_friendly()
 	{
 		$this->assert_equals('Y-m-d H:i:s', DateTime::get_format('db'));


### PR DESCRIPTION
- Added $microseconds with default set to 0 as argument
- Added test for making sure setTime with and without microseconds generate same output