### PR TITLE
Fix type of id on newly created records

### DIFF
--- a/lib/Model.php
+++ b/lib/Model.php
@@ -848,7 +848,7 @@ class Model
 			$column = $table->get_column_by_inflected_name($pk);
 
 			if ($column->auto_increment || $use_sequence)
-				$this->attributes[$pk] = static::connection()->insert_id($table->sequence);
+				$this->attributes[$pk] = $column->cast(static::connection()->insert_id($table->sequence), static::connection());
 		}
 
 		$this->__new_record = false;

--- a/test/ActiveRecordWriteTest.php
+++ b/test/ActiveRecordWriteTest.php
@@ -194,6 +194,18 @@ class ActiveRecordWriteTest extends DatabaseTest
 		$this->assert_equals(array('name','special'),array_keys($book->dirty_attributes()));
 	}
 
+	public function test_id_type()
+	{
+		$book = new Book;
+		$book->save();
+
+		$bookFromFind = Book::find($book->id);
+
+		// both should be ints
+		$this->assert_same($book->id, $bookFromFind->id);
+	}
+
+
 	public function test_dirty_attributes_cleared_after_saving()
 	{
 		$book = $this->make_new_book_and();


### PR DESCRIPTION
When new-ing a new record and doing a save, the primary key is stored as a string. It's not until you do a find that it is properly converted to the expected integer. This is because the id is retrieved directly from `static::connection()->insert_id` whereas the other attributes are passed through `set_attributes_via_mass_assignment`, which does a cast on each of the values.

Fix is to do a similar cast on the the id before it is stashed in `attributes` during the insert step.