### PR TITLE
Fix various minor bugs detected by static analyzer

### DIFF
--- a/lib/CallBack.php
+++ b/lib/CallBack.php
@@ -149,7 +149,7 @@ class CallBack
 	 * model object. For (after|before)_(create|update) callbacks, it will merge with
 	 * a generic 'save' callback which is called first for the lease amount of precision.
 	 *
-	 * @param string $model Model to invoke the callback on.
+	 * @param object $model Model to invoke the callback on.
 	 * @param string $name Name of the callback to invoke
 	 * @param boolean $must_exist Set to true to raise an exception if the callback does not exist.
 	 * @return mixed null if $name was not a valid callback type or false if a method was invoked

--- a/lib/Validations.php
+++ b/lib/Validations.php
@@ -263,7 +263,7 @@ class Validations
 				$enum = $options['within'];
 
 			if (!is_array($enum))
-				array($enum);
+				$enum = array($enum);
 
 			$message = str_replace('%s', $var, $options['message']);
 
@@ -517,7 +517,7 @@ class Validations
 						$message = $options['message'];
 					else
 						$message = $options[$messageOptions[$range_option]];
-					
+
 
 					$message = str_replace('%d', $option, $message);
 					$attribute_value = $this->model->$attribute;

--- a/lib/adapters/OciAdapter.php
+++ b/lib/adapters/OciAdapter.php
@@ -5,10 +5,11 @@
 namespace ActiveRecord;
 
 use PDO;
+use PDOException;
 
 /**
  * Adapter for OCI (not completed yet).
- * 
+ *
  * @package ActiveRecord
  */
 class OciAdapter extends Connection
@@ -29,7 +30,7 @@ class OciAdapter extends Connection
 	}
 
 	public function supports_sequences() { return true; }
-	
+
 	public function get_next_sequence_value($sequence_name)
 	{
 		return $this->query_and_fetch_one('SELECT ' . $this->next_sequence_value($sequence_name) . ' FROM dual');
@@ -60,14 +61,14 @@ class OciAdapter extends Connection
 	{
 		$offset = intval($offset);
 		$stop = $offset + intval($limit);
-		return 
+		return
 			"SELECT * FROM (SELECT a.*, rownum ar_rnum__ FROM ($sql) a " .
 			"WHERE rownum <= $stop) WHERE ar_rnum__ > $offset";
 	}
 
 	public function query_column_info($table)
 	{
-		$sql = 
+		$sql =
 			"SELECT c.column_name, c.data_type, c.data_length, c.data_scale, c.data_default, c.nullable, " .
 				"(SELECT a.constraint_type " .
 				"FROM all_constraints a, all_cons_columns b " .
@@ -109,7 +110,7 @@ class OciAdapter extends Connection
 		$c->nullable		= $column['nullable'] == 'Y' ? true : false;
 		$c->pk				= $column['pk'] == 'P' ? true : false;
 		$c->length			= $column['data_length'];
-	
+
 		if ($column['data_type'] == 'timestamp')
 			$c->raw_type = 'datetime';
 		else


### PR DESCRIPTION
- saw a no-op array statement in Validations class,
  assume `$enum = [$enum]` was intended.
- PDO wasn't namespaced in lib/adapters/OciAdapter,
  so it referred to `ActiveRecord\PDOException`
- Incorrect phpdoc in callback for $model