### PR TITLE
Change logic for default timestamp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 vendor/*
 composer.lock
 phpunit.xml
+.idea

--- a/lib/Model.php
+++ b/lib/Model.php
@@ -1142,10 +1142,10 @@ class Model
 	{
 		$now = date('Y-m-d H:i:s');
 
-		if (isset($this->updated_at))
+		if (!isset($this->updated_at))
 			$this->updated_at = $now;
 
-		if (isset($this->created_at) && $this->is_new_record())
+		if (!isset($this->created_at) && $this->is_new_record())
 			$this->created_at = $now;
 	}
 

--- a/lib/Model.php
+++ b/lib/Model.php
@@ -1142,10 +1142,10 @@ class Model
 	{
 		$now = date('Y-m-d H:i:s');
 
-		if (!isset($this->updated_at))
+		if (isset($this->updated_at) && empty($this->updated_at))
 			$this->updated_at = $now;
 
-		if (!isset($this->created_at) && $this->is_new_record())
+		if (isset($this->created_at) && empty($this->created_at) && $this->is_new_record())
 			$this->created_at = $now;
 	}
 


### PR DESCRIPTION
Change logic for default timestamp assignment for created_at and updated_at properties. Prevent overwriting values in case they are set by client

Issue also mentioned on
http://www.phpactiverecord.org/boards/4/topics/2066-re-saving-date-to-mysql-problem