### PR TITLE
Update OciAdapter.php

### DIFF
--- a/lib/adapters/OciAdapter.php
+++ b/lib/adapters/OciAdapter.php
@@ -22,6 +22,7 @@ class OciAdapter extends Connection
 	{
 		try {
 			$this->dsn_params = isset($info->charset) ? ";charset=$info->charset" : "";
+			$info->host = isset($info->port) ? "$info->host:$info->port" : "$info->host";
 			$this->connection = new PDO("oci:dbname=//$info->host/$info->db$this->dsn_params",$info->user,$info->pass,static::$PDO_OPTIONS);
 		} catch (PDOException $e) {
 			throw new DatabaseException($e);


### PR DESCRIPTION
Added the possibility to use another port instead of standard 1521 one.

You can use set_connections method passing array('prod' => "oci://$_user:$_pass@$_host:$_port/$_service").
It will call the PDO driver with the correct arguments without removing port info.