### PR TITLE
PHP 7.2 compatibility fixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "php-activerecord/php-activerecord",
     "type": "library",
     "description": "php-activerecord is an open source ORM library based on the ActiveRecord pattern.",
+    "version": "1.2.1",
     "keywords": ["activerecord", "orm"],
     "homepage": "http://www.phpactiverecord.org/",
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,6 @@
     "name": "php-activerecord/php-activerecord",
     "type": "library",
     "description": "php-activerecord is an open source ORM library based on the ActiveRecord pattern.",
-    "version": "1.2.1",
     "keywords": ["activerecord", "orm"],
     "homepage": "http://www.phpactiverecord.org/",
     "license": "MIT",

--- a/lib/Column.php
+++ b/lib/Column.php
@@ -130,8 +130,7 @@ class Column
 
 		// If adding 0 to a numeric string that is not a decimal causes a float conversion,
 		// we have a number over PHP_INT_MAX
-		elseif (is_string($value) 
-			&& is_numeric($value) && is_float($value + 0)) {
+		elseif (is_string($value) && is_numeric($value) && is_float($value + 0)) 
 			return (string) $value;
 
 		// If a float was passed and its greater than PHP_INT_MAX

--- a/lib/Column.php
+++ b/lib/Column.php
@@ -128,9 +128,10 @@ class Column
 		elseif (is_numeric($value) && floor($value) != $value)
 			return (int) $value;
 
-		// If adding 0 to a string causes a float conversion,
+		// If adding 0 to a numeric string that is not a decimal causes a float conversion,
 		// we have a number over PHP_INT_MAX
-		elseif (is_string($value) && is_float($value + 0))
+		elseif (is_string($value) 
+			&& is_numeric($value) && is_float($value + 0)) {
 			return (string) $value;
 
 		// If a float was passed and its greater than PHP_INT_MAX

--- a/lib/Model.php
+++ b/lib/Model.php
@@ -1642,7 +1642,7 @@ class Model
 	 * Finder method which will find by a single or array of primary keys for this model.
 	 *
 	 * @see find
-	 * @param array $values An array containing values for the pk
+	 * @param array|string $values An array or a comma separated string containing values for the pk
 	 * @param array $options An options array
 	 * @return Model
 	 * @throws {@link RecordNotFound} if a record could not be found
@@ -1667,7 +1667,8 @@ class Model
 		}
 		$results = count($list);
 
-		if ($results != ($expected = count($values)))
+		$count_values = (!is_array($values)) ? [$values] : $values;
+		if ($results != ($expected = count($count_values)))
 		{
 			$class = get_called_class();
 			if (is_array($values))

--- a/lib/Model.php
+++ b/lib/Model.php
@@ -1667,7 +1667,7 @@ class Model
 		}
 		$results = count($list);
 
-		$count_values = (!is_array($values)) ? [$values] : $values;
+		$count_values = (!is_array($values)) ? array($values) : $values;
 		if ($results != ($expected = count($count_values)))
 		{
 			$class = get_called_class();

--- a/lib/SQLBuilder.php
+++ b/lib/SQLBuilder.php
@@ -217,7 +217,7 @@ class SQLBuilder
 			return null;
 
 		$parts = preg_split('/(_and_|_or_)/i',$name,-1,PREG_SPLIT_DELIM_CAPTURE);
-		$num_values = count($values);
+		$num_values = count((!is_array($values)) ? array($values) : $values);
 		$conditions = array('');
 
 		for ($i=0,$j=0,$n=count($parts); $i<$n; $i+=2,++$j)

--- a/lib/SQLBuilder.php
+++ b/lib/SQLBuilder.php
@@ -217,7 +217,7 @@ class SQLBuilder
 			return null;
 
 		$parts = preg_split('/(_and_|_or_)/i',$name,-1,PREG_SPLIT_DELIM_CAPTURE);
-		$num_values = count((!is_array($values)) ? array($values) : $values);
+		$num_values = !empty($values) ? count($values) : 0;
 		$conditions = array('');
 
 		for ($i=0,$j=0,$n=count($parts); $i<$n; $i+=2,++$j)

--- a/test/ModelCallbackTest.php
+++ b/test/ModelCallbackTest.php
@@ -27,7 +27,8 @@ class ModelCallbackTest extends DatabaseTest
 	public function assert_fires($callbacks, $closure)
 	{
 		$executed = $this->register_and_invoke_callbacks($callbacks,true,$closure);
-		$this->assert_equals(count($callbacks),count($executed));
+		$count_callbacks = (is_array($callbacks)) ? $callbacks : array($callbacks);
+		$this->assert_equals(count($count_callbacks),count($executed));
 	}
 
 	public function assert_does_not_fire($callbacks, $closure)

--- a/test/helpers/AdapterTest.php
+++ b/test/helpers/AdapterTest.php
@@ -339,12 +339,14 @@ class AdapterTest extends DatabaseTest
 
 	public function test_query_column_info()
 	{
-		$this->assert_greater_than(0,count($this->conn->query_column_info("authors")));
+		$query_info = $this->conn->query_column_info("authors");
+		$this->assert_true($query_info instanceof PDOStatement);
 	}
 
 	public function test_query_table_info()
 	{
-		$this->assert_greater_than(0,count($this->conn->query_for_tables()));
+		$query_for_tables = $this->conn->query_for_tables();
+		$this->assert_true($query_for_tables instanceof PDOStatement);
 	}
 
 	public function test_query_table_info_must_return_one_field()


### PR DESCRIPTION
The current version of PHP ActiveRecords works in PHP 7.2, but generates several warnings related to count(). In PHP 7.2 this function now triggers a warning when attempting to count a non-countable type. The warning message is as follows:

> Warning: count(): Parameter must be an array or an object that implements Countable in %s on line %d

These can be very annoying for projects who are keen on keeping their error logs clean and their server disk space from running out. This is an especially large problem because one request can trigger hundreds of these warnings.

Another reason to fix these warnings is that in development environments, PHP warnings are often shown in the output.

