### PR TITLE
Fix for countable error in PHP 7.2 in find()

### DIFF
--- a/lib/Model.php
+++ b/lib/Model.php
@@ -1596,9 +1596,6 @@ class Model
 			$args = array_slice($args,1);
 			$num_args--;
 		}
-		//find by pk
-		elseif (1 === count($args) && 1 == $num_args)
-			$args = $args[0];
 
 		// anything left in $args is a find by pk
 		if ($num_args > 0 && !isset($options['conditions']))


### PR DESCRIPTION
1. $args is always an array from func_get_args()

2. static::find_by_pk() expects $args to be an array

So why are we trying to change $args from an array into a ... non-array?

This fixes the countable error in PHP 7.2 #588 #596 