### PR TITLE
Fix count php 7.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 vendor/*
 composer.lock
 phpunit.xml
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,17 @@ env: PHPAR_MYSQL=mysql://root@127.0.0.1/phpar_test PHPAR_PGSQL=pgsql://postgres@
 
 language: php
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 7.0
   - 7.1
+  - 7.2
   - nightly
 
 matrix:
   include:
+    - php: 5.3
+      dist: precise
     - php: hhvm
       dist: trusty
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,17 +7,15 @@ env: PHPAR_MYSQL=mysql://root@127.0.0.1/phpar_test PHPAR_PGSQL=pgsql://postgres@
 
 language: php
 php:
+  - 5.3
   - 5.4
   - 5.5
   - 7.0
   - 7.1
-  - 7.2
   - nightly
 
 matrix:
   include:
-    - php: 5.3
-      dist: precise
     - php: hhvm
       dist: trusty
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ php:
   - 5.5
   - 7.0
   - 7.1
+  - 7.2
   - nightly
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ env: PHPAR_MYSQL=mysql://root@127.0.0.1/phpar_test PHPAR_PGSQL=pgsql://postgres@
 
 language: php
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 7.0
@@ -16,6 +15,8 @@ php:
 
 matrix:
   include:
+    - php: 5.3
+      dist: precise
     - php: hhvm
       dist: trusty
   allow_failures:

--- a/lib/Model.php
+++ b/lib/Model.php
@@ -1667,11 +1667,13 @@ class Model
 		}
 		$results = count($list);
 
+        if (!is_array($values))
+            $values = array($values);
+
 		if ($results != ($expected = count($values)))
 		{
 			$class = get_called_class();
-			if (is_array($values))
-				$values = join(',',$values);
+			$values = join(',',$values);
 
 			if ($expected == 1)
 			{

--- a/lib/SQLBuilder.php
+++ b/lib/SQLBuilder.php
@@ -217,7 +217,7 @@ class SQLBuilder
 			return null;
 
 		$parts = preg_split('/(_and_|_or_)/i',$name,-1,PREG_SPLIT_DELIM_CAPTURE);
-		$num_values = count($values);
+        $num_values = is_null($values) ? 0 : count($values);
 		$conditions = array('');
 
 		for ($i=0,$j=0,$n=count($parts); $i<$n; $i+=2,++$j)

--- a/test/ModelCallbackTest.php
+++ b/test/ModelCallbackTest.php
@@ -26,6 +26,9 @@ class ModelCallbackTest extends DatabaseTest
 
 	public function assert_fires($callbacks, $closure)
 	{
+		if (!is_array($callbacks))
+			$callbacks = array($callbacks);
+
 		$executed = $this->register_and_invoke_callbacks($callbacks,true,$closure);
 		$this->assert_equals(count($callbacks),count($executed));
 	}

--- a/test/helpers/AdapterTest.php
+++ b/test/helpers/AdapterTest.php
@@ -339,12 +339,12 @@ class AdapterTest extends DatabaseTest
 
 	public function test_query_column_info()
 	{
-		$this->assert_greater_than(0,count($this->conn->query_column_info("authors")));
+		$this->assert_greater_than(0,count((array) $this->conn->query_column_info("authors")));
 	}
 
 	public function test_query_table_info()
 	{
-		$this->assert_greater_than(0,count($this->conn->query_for_tables()));
+		$this->assert_greater_than(0,count((array) $this->conn->query_for_tables()));
 	}
 
 	public function test_query_table_info_must_return_one_field()


### PR DESCRIPTION
- Fixed count() error in php 7.2
- Added php 7.2 on trevis tests
- Fix count() errors on phpunit tests
- Change travis test php 5.3 to Precise, because now is necessary explicitly stay on Precise. See warning note in the last travis builder of PHP 5.3.