### PR TITLE
Fix deprecation in PHP 7.4

### DIFF
--- a/ActiveRecord.php
+++ b/ActiveRecord.php
@@ -40,7 +40,7 @@ function activerecord_autoload($class_name)
 		foreach ($namespaces as $directory)
 			$directories[] = $directory;
 
-		$root .= DIRECTORY_SEPARATOR . implode($directories, DIRECTORY_SEPARATOR);
+		$root .= DIRECTORY_SEPARATOR . implode(DIRECTORY_SEPARATOR, $directories);
 	}
 
 	$file = "$root/$class_name.php";


### PR DESCRIPTION
PHP 7.4 deprecates reversed order of arguments for implode function. This fixes deprecation notice.