### PR TITLE
Fix the warning in ActiveRecord.php "PHP Deprecated:  implode(): Pass…

### DIFF
--- a/ActiveRecord.php
+++ b/ActiveRecord.php
@@ -40,7 +40,7 @@ function activerecord_autoload($class_name)
 		foreach ($namespaces as $directory)
 			$directories[] = $directory;
 
-		$root .= DIRECTORY_SEPARATOR . implode($directories, DIRECTORY_SEPARATOR);
+		$root .= DIRECTORY_SEPARATOR . implode(DIRECTORY_SEPARATOR, $directories);
 	}
 
 	$file = "$root/$class_name.php";


### PR DESCRIPTION
Fix the warning in ActiveRecord.php "PHP Deprecated:  implode(): Passing glue string after array is deprecated. Swap the parameters"